### PR TITLE
Fix: Install missing dependencies in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install dilithium numpy
 
       - name: Run Gaia-Techne AGI
         run: |


### PR DESCRIPTION
The `validate_gaia_techne` job in the CI workflow was failing because the `dilithium` and `numpy` packages were not being installed. This change adds the necessary `pip install` commands to the workflow to ensure that the required dependencies are available during the execution of the Python scripts.