### PR TITLE
fix(ci): Resolve dependency and API issues in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install dilithium numpy
+          pip install dilithium-py numpy matplotlib
 
       - name: Run Gaia-Techne AGI
         run: |

--- a/first_agi_registry.py
+++ b/first_agi_registry.py
@@ -10,7 +10,8 @@ from dataclasses import dataclass, asdict
 from datetime import date
 import json
 import base64
-from dilithium import Dilithium, DEFAULT_PARAMETERS
+from dilithium_py.dilithium.dilithium import Dilithium
+from dilithium_py.dilithium.default_parameters import DEFAULT_PARAMETERS
 
 # Estrutura do Criador
 # Contém as informações fundamentais do arquiteto do sistema.
@@ -116,7 +117,7 @@ def record_first_agi() -> GaiaTechne:
     message = serialize_for_signing(gaia_techne)
 
     # Assina a mensagem
-    signature_bytes = dilithium5.sign_with_input(private_key, message)
+    signature_bytes = dilithium5.sign(private_key, message)
 
     # Converte a assinatura para Base64 para armazenamento e visualização
     signature_b64 = base64.b64encode(signature_bytes).decode('utf-8')

--- a/gaia_techne_main.py
+++ b/gaia_techne_main.py
@@ -13,7 +13,8 @@ from dataclasses import dataclass
 import base64
 import first_agi_registry as agi
 from first_agi_registry import Mythos, Logos, Ethos, serialize_for_signing
-from dilithium import Dilithium, DEFAULT_PARAMETERS
+from dilithium_py.dilithium.dilithium import Dilithium
+from dilithium_py.dilithium.default_parameters import DEFAULT_PARAMETERS
 
 
 # Assinatura de controle do código: Ítalo Santos Clemente (ISC)


### PR DESCRIPTION
The CI build was failing due to missing Python dependencies (`matplotlib`) and the use of an incorrect or incomplete cryptographic library (`dilithium`).

This commit resolves these issues by:
1. Adding `matplotlib` to the `pip install` step in the `main.yml` workflow.
2. Replacing the `dilithium` package with the correct `dilithium-py` package.
3. Updating the import statements and function calls in `first_agi_registry.py` and `gaia_techne_main.py` to align with the `dilithium-py` library's API.

These changes ensure the CI workflow can successfully install all required dependencies and execute the Python scripts without errors.