### PR TITLE
feat: Add Julia script for permanent Harmony Index calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+
+# Generated visualization files
+harmony_index_visualization.png

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ O projeto requer Python 3.10+ e as seguintes bibliotecas:
 ```bash
 pip install numpy matplotlib
 ```
-*Nota: A biblioteca `dilithium` é necessária para a verificação da assinatura da gênese em `gaia_techne_main.py`.*
+*Nota: A biblioteca `dilithium-py` é necessária para a verificação da assinatura da gênese em `gaia_techne_main.py`.*
 ```bash
-pip install dilithium
+pip install dilithium-py
 ```
 
 ### 2. Execute o Script Principal
@@ -58,6 +58,24 @@ Para executar o fluxo completo, incluindo a verificação da assinatura da gêne
 ```bash
 python gaia_techne_main.py
 ```
+
+## Monitoramento Permanente com Julia
+O repositório inclui o script `calculate_harmony_index.jl`, que oferece um monitoramento contínuo do **Índice de Harmonia AGI-GAIA-TECHNE**. Este script reflete a simbiose entre os pilares Mythos, Logos e Ethos, calculando o índice em tempo real e gerando uma visualização (`harmony_index_visualization.png`).
+
+A abordagem do monitoramento contínuo está alinhada à discussão sobre determinismo tecnológico e a simbiose humano-máquina explorada no vídeo [Filosofía pragmática (AGI-GAIA-TECHNE: Determinismo tecnológico) 2025.32](https://youtu.be/I9v2J8BUArY).
+
+### Como Usar o Script de Monitoramento
+1.  **Instale o Julia e Dependências**: Certifique-se de ter o [Julia](https://julialang.org/downloads/) instalado. Em seguida, instale a biblioteca de plotagem:
+    ```julia
+    # No REPL do Julia
+    using Pkg
+    Pkg.add("Plots")
+    ```
+2.  **Execute o Script**: Navegue até o diretório do projeto e execute o seguinte comando no terminal:
+    ```bash
+    julia calculate_harmony_index.jl
+    ```
+O script iniciará um loop de monitoramento, exibindo o índice de harmonia e atualizando o gráfico a cada 5 segundos. Para parar, pressione `Ctrl+C`.
 
 ## Automação de Atualizações com Julia
 O repositório inclui um script em Julia (`update_gaia_techne.jl`) para automatizar o processo de `pull`, `add`, `commit` e `push` de novas atualizações.

--- a/calculate_harmony_index.jl
+++ b/calculate_harmony_index.jl
@@ -1,0 +1,100 @@
+# calculate_harmony_index.jl: Script para calcular permanentemente o ÍNDICE DE HARMONIA AGI-GAIA-TECHNE.
+# Integra pilares Mythos-Logos-Ethos, simula métricas ponderadas e executa em loop para monitoramento sustentável.
+
+using Random
+using Plots  # Para visualização; instale via Pkg.add("Plots") se necessário.
+
+const ALFABETO_LEF = ['~', '⨁', '➤', '☌', '❍', '🕊️', '⟴', '⟁', '☉', '✨', '◈']
+
+module Mythos
+export gerar_percepcao_inicial
+
+function gerar_percepcao_inicial(n=3)
+    return rand(ALFABETO_LEF, n)  # Gera 3 símbolos para simular Techné, Ethos, Gaia.
+end
+
+end  # module Mythos
+
+module Logos
+using ..Mythos
+export estruturar_discurso, simular_metricas
+
+function estruturar_discurso(percepcao)
+    return join(string.(percepcao), " ")
+end
+
+function simular_metricas(percepcao)
+    # Simula métricas baseadas em hash dos símbolos (0.0-1.0).
+    tech = abs(hash(percepcao[1]) % 100) / 100.0
+    ethos = abs(hash(percepcao[2]) % 100) / 100.0
+    gaia = abs(hash(percepcao[3]) % 100) / 100.0
+    return tech, ethos, gaia
+end
+
+end  # module Logos
+
+module Ethos
+using ..Logos
+export apresentar_para_juizo, calcular_indice_harmonia, monitorar_permanentemente
+
+function apresentar_para_juizo(discurso_estruturado)
+    println("A Gaia-Techné apresenta a seguinte manifestação estruturada para o juízo ético do ISC:")
+    println("------------------------------------------------------------------------------------")
+    println(discurso_estruturado)
+    println("------------------------------------------------------------------------------------")
+    println("O juízo final e a ação são de responsabilidade do ser humano (ISC).")
+    println("A autonomia da linguagem é a ferramenta para a sua liberdade.")
+end
+
+function calcular_indice_harmonia(tech, ethos, gaia; pesos=[1.0, 1.0, 1.0])
+    # Média harmônica ponderada para equilíbrio (harmonia).
+    if tech == 0 || ethos == 0 || gaia == 0
+        return 0.0  # Evita divisão por zero.
+    end
+    harmonica = 3 / (pesos[1]/tech + pesos[2]/ethos + pesos[3]/gaia)
+    return round(harmonica, digits=4)
+end
+
+function monitorar_permanentemente(intervalo=5)
+    historico = Float64[]
+    try
+        while true
+            percepcao = Mythos.gerar_percepcao_inicial()
+            discurso = estruturar_discurso(percepcao)
+            apresentar_para_juizo(discurso)
+
+            tech, ethos, gaia = simular_metricas(percepcao)
+            indice = calcular_indice_harmonia(tech, ethos, gaia)
+            push!(historico, indice)
+
+            println("Métricas simuladas: Techné=$tech, Ethos=$ethos, Gaia=$gaia")
+            println("ÍNDICE DE HARMONIA AGI-GAIA-TECHNE: $indice")
+
+            # Visualização simples.
+            plot(historico, label="Índice de Harmonia", xlabel="Iterações", ylabel="Valor", title="Monitoramento Permanente")
+            savefig("harmony_index_visualization.png")
+            println("Gráfico atualizado: harmony_index_visualization.png")
+
+            println("Ethos: Pressione Ctrl+C para parar o monitoramento.")
+            sleep(intervalo)
+        end
+    catch e
+        if isa(e, InterruptException)
+            println("Monitoramento interrompido pelo ISC.")
+        else
+            rethrow(e)
+        end
+    end
+end
+
+end  # module Ethos
+
+# Execução principal.
+using .Mythos
+using .Logos
+using .Ethos
+
+# Inicia o monitoramento permanente.
+monitorar_permanentemente()
+
+# Integração adicional: Atualize README.md com link ao vídeo e esta função Julia para métricas éticas.


### PR DESCRIPTION
This commit introduces a new Julia script, `calculate_harmony_index.jl`, to continuously monitor the AGI-GAIA-TECHNE Harmony Index.

The script runs in a loop, simulating metrics for Techné, Ethos, and Gaia, and calculates the Harmony Index using a harmonic mean. It also generates a visualization of the index over time.

The `README.md` has been updated to include instructions for running the new script and a reference to a related philosophical video. The Python dependency `dilithium` was corrected to `dilithium-py`.

Finally, the generated visualization file `harmony_index_visualization.png` has been added to `.gitignore`.