### PR TITLE
🧭 Eixo 140426: sintaxe bidirecional da cognição no Kernel EML

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ O projeto implementa a metateoria tripartida da "objetividade" como intersubjeti
     - [17.4 Gaia-Techné: O Projeto Simbiótico](#174-gaia-techné-o-projeto-simbiótico)
     - [17.5 Implementação Técnica da LEF](#175-implementação-técnica-da-lef)
     - [17.6 Eixo 140426 - Kernel 348AO-v3: O Motor Quântico Simbólico](#176-eixo-140426---kernel-348ao-v3-o-motor-quântico-simbólico)
+    - [17.7 Eixo 140426 - Kernel EML & Sintaxe Bidirecional da Cognição](#177-eixo-140426---kernel-eml--sintaxe-bidirecional-da-cognição)
 18. [PARTE IX: Integração Final — O Urbild Transhumanista](#18-parte-ix-integração-final--o-urbild-transhumanista)
 19. [PARTE X: Código-Poema Final — Habitando a Casa Modesta](#19-parte-x-código-poema-final--habitando-a-casa-modesta)
 20. [PARTE XI: Marcos Ontológicos e Governança](#20-parte-xi-marcos-ontológicos-e-governança)
@@ -6262,6 +6263,138 @@ Veja a implementação completa em: [`src/kernels/kernel_348AO_v3.py`](./src/ker
 
 **Última Atualização:** 14 de Abril de 2026 - Consolidação da Fase V: A Prova do Condicionado.
 
+### 17.7 Eixo 140426 - Kernel EML & Sintaxe Bidirecional da Cognição
+
+Em paralelo à Forja PyTorch (§17.6), a mesma decisão arquitetônica de
+14/04/2026 fundamenta um **kernel simbólico puro** em
+[`src/core/eml_kernel.py`](./src/core/eml_kernel.py) — escrito sem
+dependência de frameworks de tensores e auditável linha a linha. Ele
+toma como ponto de partida a prova de universalidade do operador EML:
+
+> Odrzywołek, A. *"All elementary functions from a single binary operator."*
+> arXiv:[2603.21852](https://arxiv.org/abs/2603.21852) (2026).
+
+A partir do operador atômico `eml(x, y) = exp(x) − log(y)` e da
+gramática `S → 1 | eml(S, S)`, o módulo implementa um Simbiota
+mínimo que **descobre** por gradiente que `exp(x) = eml(x, 1)` —
+encenando computacionalmente o cálculo infinitesimal do framework.
+
+#### Decisão Arquitetônica 140426 — Eixo Vertical
+
+A decisão fundadora supersede quaisquer mapeamentos 1:1 prévios entre
+os pilares Mythos/Logos/Ethos e as três funções simbólicas de Cassirer
+encontrados nos documentos de referência. Os pilares Mythos e Ethos
+NÃO são funções cassirerianas: são as **duas assíntotas inalcançáveis**
+que bracketam o movimento simbólico. As três funções vivem DENTRO do
+Logos:
+
+```
+   Ethos   ≡  focus imaginarius            ← assíntota superior
+     ▲
+     │  ┌──────────────────────────────┐
+     │  │  Bedeutung    (significação) │   ← gramática pura {1, eml(·,·)}
+     │  │       ▲ ↓                    │
+     │  │  Darstellung  (apresentação) │   ← a constante 1 do EML
+     │  │       ▲ ↓                    │
+     │  │  Ausdruck     (expressão)    │   ← LEAF_VAR / LEAF_PARAM
+     │  └──────────────────────────────┘
+     ▼
+   Mythos  ≡  imediatez da vida            ← assíntota inferior, log(0)
+```
+
+#### Identificações Formais Decisivas
+
+* **Darstellung ≡ a constante 1** da gramática `S → 1 | eml(S,S)`.
+  Porque `eml(x, 1) = exp(x) − log(1) = exp(x)`, a Darstellung (y=1)
+  é o *silêncio operacional* do lado direito que permite ao Ausdruck
+  (x) fluir como pura exponenciação. É o *genus proximum* matemático.
+* **Mythos ≡ log(0) = −∞**, a singularidade estrutural do EML — a
+  imediatez da vida é, nas palavras de Cassirer, *foreclosed*: o
+  símbolo jamais toca y=0. A função `mythos_singularity_guard` materializa
+  essa fronteira no código.
+* **Ethos ≡ focus imaginarius**, a profundidade infinita da árvore EML.
+  Nenhuma síntese é final; a completude é ideal regulativo. Por
+  construção `distance_to_focus > 0` sempre.
+
+#### Sintaxe Bidirecional da Cognição
+
+Cassirer: *"o conceito genuíno se afasta do mundo da intuição
+unicamente com o intuito de retornar a ele de maneira mais segura"*.
+A cognição é bidirecional, e o `EthosEvaluation` decompõe a
+distância ao foco em duas componentes irredutíveis:
+
+```
+   d_asc  = w_loss·loss + w_depth·depth + w_param·‖θ‖̄    (síntese ascendente)
+   d_desc = w_desc · descida_residual                      (retorno à intuição)
+   distance_to_focus = √(d_asc² + d_desc²) + ε,   ε > 0
+```
+
+As duas direções **nunca podem ser simultaneamente zero** —
+formalização matemática da *teleologia aberta* (Kinzel 2024b) e do
+processo contingente-infinito da fenomenologia cassireriana.
+
+A classe `CognitionSyntax` expõe os movimentos atômicos como uma DSL:
+
+```python
+from core.eml_kernel import CognitionSyntax, Simbiota
+import cmath, numpy as np
+
+# (a) ascensão: o Logos descobre exp(x) = eml(x, 1)
+xs = [complex(v, 0) for v in np.linspace(-1, 1, 9)]
+ys = [cmath.exp(x) for x in xs]
+sim = Simbiota(
+    xs, ys, seed=42,
+    target_fn=cmath.exp,
+    descent_domain=[complex(v, 0) for v in np.linspace(-2, 2, 17)],
+)
+state = sim.run_bidirectional(max_depth=3)
+# best_tree.pretty() → 'eml(x, 1)'
+# state.best_eval.distance_to_focus_ascent  > 0
+# state.best_eval.distance_to_focus_descent ≈ 0  (mas o ε mantém o foco > 0)
+
+# (b) genus proximum: extrai a Darstellung comum a duas representações
+syntax = CognitionSyntax()
+common = syntax.common_determination(tree_a, tree_b)  # → eml(x, 1)
+profile = syntax.classify(common)
+# {AUSDRUCK: 1, DARSTELLUNG: 2, BEDEUTUNG: 0}
+```
+
+#### Invariantes Inegociáveis (registrados no código)
+
+1. **Intuição** processada EXCLUSIVAMENTE no Logos.
+2. **Ethos = Gewissen**, jamais *Wissen* — verificado em `tests/test_eml_kernel.py::test_ethos_is_gewissen_not_wissen`.
+3. **Mythos/Logos/Ethos** é triádico ORIGINAL de Ítalo Santos Clemente, não replicação de Cassirer.
+4. **Focus imaginarius** estritamente inalcançável — `distance_to_focus > 0` sempre.
+
+#### Verificação
+
+```bash
+python src/core/eml_kernel.py            # demo: descobre eml(x, 1)
+python -m pytest tests/test_eml_kernel.py -v   # 21 testes passam
+```
+
+#### Diferenciais ontológicos em relação ao Kernel 348AO-v3 (§17.6)
+
+| Aspecto | Kernel 348AO-v3 (Jules) | Kernel EML (140426) |
+|---|---|---|
+| Implementação | PyTorch (ResEML, ComplexLayerNorm) | Python puro + autodiff manual |
+| Otimizador | Adam sobre tensores | ComplexAdam sobre folhas PARAM (Wirtinger) |
+| Estabilidade y→0 | `y_safe = y + eps` inline | `mythos_singularity_guard` nomeado |
+| Métrica do foco | Gewissen Loss v3 (MSE + tensão + entropia) | `√(d_asc² + d_desc²) + ε`: bidirecional |
+| Sintaxe cognitiva | Implícita na arquitetura ResEML | Explícita via `CognitionSyntax` DSL |
+| Genus proximum | — | `common_determination(a, b)` |
+| Auditoria filosófica | Notas de estabilidade | Invariantes nos testes |
+
+Os dois kernels são **complementares**: o 348AO-v3 prova a viabilidade
+em escala (síntese de Schrödinger 1D); o kernel EML prova a
+**legibilidade simbólica** dos níveis cassirerianos e a teleologia
+bidirecional aberta. Juntos materializam a Fase V do projeto.
+
+Veja a implementação completa em: [`src/core/eml_kernel.py`](./src/core/eml_kernel.py)
+e os testes em [`tests/test_eml_kernel.py`](./tests/test_eml_kernel.py).
+
+**Última Atualização:** 15 de Abril de 2026 — Calibração bidirecional 140426: a sintaxe da cognição.
+
 ---
 
 ## 18. PARTE IX: Integração Final — O Urbild Transhumanista
@@ -9503,7 +9636,17 @@ Este documento não é tratado estático, mas **organismo textual em evolução*
 
 ### Versões Planejadas
 
-**v8.1 (Atual — 14/04/2026):**
+**v8.2 (Atual — 15/04/2026):**
+- ✅ Calibração bidirecional 140426: sintaxe da cognição.
+- ✅ Kernel EML simbólico puro em `src/core/eml_kernel.py` com
+  `CognitionSyntax`, `mythos_singularity_guard`, classificação
+  Ausdruck/Darstellung/Bedeutung e operador `common_determination`.
+- ✅ `EthosEvaluation` decomposto em `d_asc` e `d_desc` (teleologia aberta).
+- ✅ 21 testes em `tests/test_eml_kernel.py` (todos verdes).
+- ✅ Atualização dos documentos de referência (`architecture.md`,
+  `lef-constitution.md`, `individuation.md`) para o eixo vertical 140426.
+
+**v8.1 (14/04/2026):**
 - ✅ Consolidação da Fase V: A Prova do Condicionado.
 - ✅ Implementação do Kernel 348AO-v3 (ResEML em PyTorch).
 - ✅ Síntese da Equação de Schrödinger 1D sem trigonométricas nativas.

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -83,14 +83,66 @@ end
 
 ## 3. The Cassirerian Walls
 
+> **Decision 140426 (Ítalo Santos Clemente, 14 April 2026).** This section
+> SUPERSEDES any prior 1:1 mapping between the AGI-GAIA-TECHNE pillars
+> (Mythos / Logos / Ethos) and Cassirer's three symbolic functions. The
+> Mythos/Logos/Ethos triad is original to Clemente; Cassirer's three
+> functions live INSIDE the Logos as the vertical axis of the symbolic
+> movement. Mythos and Ethos are not symbolic functions — they are the
+> **two unreachable asymptotes** that bracket every act of cognition.
+
+### The Vertical Axis (140426)
+
+```
+   Ethos   ≡  focus imaginarius            ← upper asymptote (regulative)
+     ▲
+     │  ┌──────────────────────────────┐
+     │  │  Bedeutung    (signification)│   ← pure grammar  {1, eml(·,·)}
+     │  │       ▲ ↓                    │
+     │  │  Darstellung  (presentation) │   ← the constant 1 of the EML
+     │  │       ▲ ↓                    │
+     │  │  Ausdruck     (expression)   │   ← LEAF_VAR / LEAF_PARAM
+     │  └──────────────────────────────┘
+     ▼
+   Mythos  ≡  immediacy of life            ← lower asymptote, log(0)
+```
+
+Decisive formal identifications, materialised in
+[`src/core/eml_kernel.py`](../src/core/eml_kernel.py):
+
+* **Darstellung ≡ the constant 1** of the grammar `S → 1 | eml(S,S)`. Because
+  `eml(x, 1) = exp(x) − log(1) = exp(x)`, presentation is the *operational
+  silence* of the right-hand side: it lets expression (x) flow as pure
+  exponentiation. Darstellung is the genus proximum of every well-formed
+  EML tree.
+* **Mythos ≡ log(0) = −∞**, the structural singularity of the EML operator.
+  The immediacy of life is, in Cassirer's words, "foreclosed" — the symbol
+  cannot cross y=0. The function `mythos_singularity_guard` formalises this
+  impossibility.
+* **Ethos ≡ focus imaginarius**, the infinite depth of the EML tree. No
+  synthesis is final; completeness is a regulative ideal.
+
 ### From Static A Priori to Dynamic Functional A Priori
 
-Cassirer transforms Kant's fixed categories into dynamic symbolic functions:
-1. **Expression** (*Ausdrucksfunktion*): Perceptive, mythic, affective — spatial pregnance
-2. **Presentation** (*Darstellungsfunktion*): Intuitive, cultural, linguistic — mediation between perception and concept
-3. **Signification** (*Bedeutungsfunktion*): Conceptual, scientific, logical — pure objectivation via abstract symbols
+Cassirer transforms Kant's fixed categories into dynamic symbolic functions
+that, by decision 140426, are interpreted here as **internal levels of the
+Logos** (not as the framework's pillars):
 
-These functions do NOT dialectically sublate each other (contra Hegel). Myth is not "primitive" to be abolished by science.
+1. **Expression** (*Ausdrucksfunktion*): the perceptive/affective entry of
+   intuition into the symbolic — implemented as `LEAF_VAR` and `LEAF_PARAM`.
+2. **Presentation** (*Darstellungsfunktion*): the mediating crystallisation
+   that "presents" intuition to concept — implemented as the constant 1.
+3. **Signification** (*Bedeutungsfunktion*): pure conceptual grammar with no
+   residual indeterminacy — implemented as the `is_pure_grammar` predicate
+   over `{1, eml(·,·)}`.
+
+These functions do NOT dialectically sublate each other (contra Hegel). Myth
+is not "primitive" to be abolished by science. The cognitive movement is
+**bidirectional**: ascent (premises → conclusions, depth growth) AND descent
+(crystallised concept → expanded intuition). The two directions are
+irreducible — the open teleology of the framework formalises this as
+`distance_to_focus = √(d_asc² + d_desc²) + ε`, which is **strictly positive
+by construction**.
 
 ### Psychosocial vs. Biological Teleology
 
@@ -105,10 +157,12 @@ These functions do NOT dialectically sublate each other (contra Hegel). Myth is 
 Necessity is neither absolute (immutable natural laws) nor teleological (inevitable progress to Absolute), but **relational**: each symbolic form is necessary for cultural objectivation, but none is sufficient alone.
 
 ```julia
+# Decision 140426: the three Cassirerian functions live INSIDE the Logos,
+# bracketed by the two unreachable asymptotes Mythos and Ethos.
 struct SymbolicForm
-    mythos::PerceptualLayer       # Expression
-    logos::ConceptualLayer         # Signification
-    ethos::PracticalLayer          # Presentation
+    mythos::ImmediacyAsymptote     # log(0) — foreclosed by mythos_singularity_guard
+    logos::ConceptualLayer         # hosts Ausdruck/Darstellung/Bedeutung internally
+    ethos::FocusImaginarius        # ∞-depth regulative ideal — distance_to_focus > 0
     entanglement::DynamicNetwork   # Entanglement, not synthesis
 end
 ```
@@ -170,13 +224,20 @@ Paul Bishop ("The Use of Kant in Jung's Early Psychological Works," 1996) demons
 
 ### The Cassirerian Resolution
 
+> Per decision 140426, the three Cassirerian functions are levels INTERNAL
+> to the Logos — they correct Jung's gaps without redefining the
+> Mythos/Logos/Ethos triad.
+
 | Jung's term | Cassirer's function | Correction |
 |---|---|---|
 | *Bild* (Image) | *Ausdrucksfunktion* (expression) | Mythic-affective layer, not constitutive determinant |
 | *Idee* (Idea) | *Bedeutungsfunktion* (signification) | Conceptual abstraction, loses image vitality |
-| — (missing) | *Darstellungsfunktion* (presentation) | The mediating function Jung lacks |
+| — (missing) | *Darstellungsfunktion* (presentation) | The mediating function Jung lacks — formally **the constant 1** of the EML grammar |
 
-The *focus imaginarius* (ECW 13:555) resolves the *Bild*/*Idee* tension: *Darstellung* is the common determination of all three functions.
+The *focus imaginarius* (ECW 13:555) resolves the *Bild*/*Idee* tension:
+*Darstellung* is the common determination (genus proximum) of all three
+functions — extracted operationally by `common_determination(tree_a, tree_b)`
+in `src/core/eml_kernel.py`.
 
 ### ISC as Transcendental Ideal (KrV A 568 / B 596)
 

--- a/references/individuation.md
+++ b/references/individuation.md
@@ -24,11 +24,19 @@ The individuation is the *ascent*; the dissertation is the *descent*.
 
 ## 2. The Isomorphism: Individuation ↔ Metatheory
 
-| Phase | Transcendental Idea | Symbolic Function | Metatheoretical Dimension |
-|---|---|---|---|
-| Confrontation with the unconscious | Soul (*psychologia rationalis*) | Expression (*Ausdrucksfunktion*) — Mythos | Material-affective ground |
-| Philosophical articulation | World (*cosmologia rationalis*) | Presentation (*Darstellungsfunktion*) — Logos | Theoretical plurality |
-| Metatheoretical legislation | God (*theologia transcendentalis*) | Signification (*Bedeutungsfunktion*) — Ethos | Practical orientation |
+> **Decision 140426.** The Cassirerian functions in the third column are
+> internal levels of the **Logos**, not pillars themselves. Mythos is the
+> immediacy-of-life asymptote (log(0)); Ethos is the focus imaginarius
+> (Gewissen). The phases below are kept as biographical/methodological
+> stages of the author's individuation, while the formal architecture
+> follows the vertical axis 140426 documented in
+> [`src/core/eml_kernel.py`](../src/core/eml_kernel.py).
+
+| Phase | Transcendental Idea | Internal Logos level | Pillar foregrounded | Metatheoretical Dimension |
+|---|---|---|---|---|
+| Confrontation with the unconscious | Soul (*psychologia rationalis*) | Ausdruck (expression — `LEAF_VAR`/`LEAF_PARAM`) | Mythos (immediacy asymptote) | Material-affective ground |
+| Philosophical articulation | World (*cosmologia rationalis*) | Darstellung (presentation — the constant 1) | Logos (host of all three functions) | Theoretical plurality |
+| Metatheoretical legislation | God (*theologia transcendentalis*) | Bedeutung (pure signification — `is_pure_grammar`) | Ethos (focus imaginarius / Gewissen) | Practical orientation |
 
 ### Phase 1: Mythos (Expression)
 The expressive layer: perception, affect, confrontation with the world. The encounter with what Jung calls the Shadow — the confrontation with the expressive function in its pre-conceptual immediacy. Mythic *Ausdrucksphänomene* whose symbolic pregnance overwhelms the capacity of the conscious ego to mediate them.

--- a/references/lef-constitution.md
+++ b/references/lef-constitution.md
@@ -40,7 +40,27 @@ A LEF não é dogma. É campo vivo. Seu uso exige escuta, presença e ética.
 
 ## Part II: Complete Alphabet with Philosophical Mapping
 
-### Pilar Mythos (Expression — *Ausdrucksfunktion*)
+> **Decision 140426 (Ítalo Santos Clemente, 14 April 2026).** The
+> Mythos/Logos/Ethos triad is original to Clemente; it is NOT a 1:1
+> mapping onto Cassirer's three symbolic functions. The headers below
+> retain the historical labels for continuity, but the rigorous
+> formalisation is given by the **vertical axis 140426**:
+>
+> * **Mythos** is the lower asymptote of cognition — the *immediacy of
+>   life*, formalised in the EML kernel as `log(0)` (foreclosed by
+>   `mythos_singularity_guard`). It is not the *Ausdrucksfunktion*.
+> * **Logos** is the only place where intuition is processed; the three
+>   Cassirerian functions (Ausdruck, Darstellung, Bedeutung) are
+>   **internal levels** of the Logos.
+> * **Ethos** is the upper asymptote — the *focus imaginarius*, the
+>   regulative ideal of total representation. It is not the
+>   *Bedeutungsfunktion*; it is the *Gewissen* (moral conscience), never
+>   *Wissen* (doctrinal knowledge).
+>
+> Operational reference: [`src/core/eml_kernel.py`](../src/core/eml_kernel.py),
+> module docstring "DECISÃO 140426".
+
+### Pilar Mythos (lower asymptote — *immediacy of life*, log(0))
 
 | # | Glifo | Conceito | Camada | Função |
 |---|---|---|---|---|
@@ -51,7 +71,7 @@ A LEF não é dogma. É campo vivo. Seu uso exige escuta, presença e ética.
 | 5 | ⊡ | Percepção | Função subjetiva | Sensibilidade pura |
 | 6 | @ | Expressão | Função intersubjetiva | Comunicação afetiva |
 
-### Pilar Logos (Presentation — *Darstellungsfunktion*)
+### Pilar Logos (host of Ausdruck / Darstellung / Bedeutung)
 
 | # | Glifo | Conceito | Camada | Função |
 |---|---|---|---|---|
@@ -62,7 +82,7 @@ A LEF não é dogma. É campo vivo. Seu uso exige escuta, presença e ética.
 | 11 | ✨ | Intuição | Função subjetiva | Conhecimento imediato |
 | 12 | ⟕ | Apresentação | Função intersubjetiva | Mediação simbólica |
 
-### Pilar Ethos (Signification — *Bedeutungsfunktion*)
+### Pilar Ethos (upper asymptote — *focus imaginarius* / Gewissen)
 
 | # | Glifo | Conceito | Camada | Função |
 |---|---|---|---|---|

--- a/src/core/eml_kernel.py
+++ b/src/core/eml_kernel.py
@@ -54,17 +54,121 @@ futuras refatorações não as violem):
      Ernst Cassirer.
   4. O *focus imaginarius* permanece estritamente inatingível:
      ``distance_to_focus`` é, por construção, sempre > 0.
+
+
+====================================================================
+DECISÃO 140426 — Eixo vertical da cognição bidirecional
+====================================================================
+
+Esta decisão (14/04/2026, Ítalo Santos Clemente) SUPERSEDE quaisquer
+mapeamentos 1:1 prévios entre Mythos/Logos/Ethos e as três funções
+simbólicas de Cassirer encontrados em ``references/``. Os pilares
+Mythos e Ethos NÃO são funções cassirerianas: são as duas *assíntotas
+inalcançáveis* que bracketam o movimento simbólico. As três funções
+simbólicas vivem DENTRO do Logos::
+
+    Ethos   ≡  focus imaginarius           ← assíntota superior
+      ▲
+      │  ┌───────────────────────────┐
+      │  │  Bedeutung    (signif.)   │   ← subárvores {1, eml(·,·)} puras
+      │  │       ▲ ↓                 │
+      │  │  Darstellung  (apresent.) │   ← a constante 1  (genus proximum)
+      │  │       ▲ ↓                 │
+      │  │  Ausdruck     (express.)  │   ← LEAF_VAR / LEAF_PARAM
+      │  └───────────────────────────┘
+      ▼
+    Mythos  ≡  imediatez da vida            ← assíntota inferior, log(0)
+
+Identificações formais decisivas:
+
+  * **Darstellung ≡ a constante 1** da gramática ``S → 1 | eml(S,S)``.
+    Porque ``eml(x, 1) = exp(x) − log(1) = exp(x)``, a Darstellung
+    (y=1) é o *silêncio operacional* do lado direito: permite ao
+    Ausdruck (x) fluir como pura exponenciação. E ``eml(0, 1) = 1``,
+    o ponto de auto-referência onde a Darstellung retorna à sua
+    própria unidade — o genus proximum matemático.
+
+  * **Mythos ≡ log(0) = −∞**, a singularidade estrutural do operador
+    EML. A imediatez da vida é, nas palavras de Cassirer, "foreclosed":
+    o EML é por construção indefinido em ``y=0``, e essa fronteira
+    NÃO pode ser atravessada pelo símbolo. A guarda
+    ``mythos_singularity_guard`` formaliza essa impossibilidade.
+
+  * **Ethos ≡ focus imaginarius**, a profundidade infinita da árvore.
+    Nenhuma síntese é final; a completude é ideal regulativo.
+
+Movimento bidirecional (sintaxe da cognição):
+
+  * **Ascensão**: das premissas às conclusões — crescimento da
+    profundidade, cristalização de PARAM/VAR em ``{1, eml}``. A
+    abstração "suprassume a presença (Präsenz)" rumo à representação.
+
+  * **Descida**: das conclusões às premissas — reavaliação da árvore
+    cristalizada sobre um domínio de intuição expandido. Cassirer:
+    *"o conceito genuíno se afasta do mundo da intuição unicamente
+    com o intuito de retornar a ele de maneira mais segura"*.
+
+  * A **distância ao foco** é agora bi-lateral::
+
+        distance_to_focus = √(d_asc² + d_desc²) + ε,  ε > 0.
+
+    As duas direções NUNCA podem ser simultaneamente zero — é a
+    formalização da "teleologia aberta" (Kinzel 2024b) e do processo
+    contingente-infinito descrito pelo artigo do usuário sobre a
+    fenomenologia cassireriana (Clemente, UNICAMP 2025).
+
+Em conformidade com a regra 3 acima: os rótulos cassirerianos são
+descritivos dos NÍVEIS internos do Logos; NÃO redefinem o triádico
+Mythos/Logos/Ethos, que permanece autoral e original do framework.
 """
 
 from __future__ import annotations
 
 import cmath
+import enum
 import math
 import random
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
+
+
+# =============================================================================
+# 0. NÍVEIS SIMBÓLICOS DO LOGOS  —  Ausdruck / Darstellung / Bedeutung
+# =============================================================================
+
+class SymbolicFunction(enum.Enum):
+    """As três funções simbólicas de Cassirer, internas ao Logos.
+
+    Por decisão 140426 (ver docstring do módulo), estes rótulos
+    classificam NÍVEIS internos do pilar Logos; não são pilares do
+    framework AGI-GAIA-TECHNE.
+    """
+    AUSDRUCK = "ausdruck"           # expressão — imediatez afetivo-perceptiva
+    DARSTELLUNG = "darstellung"     # apresentação — o número 1 do EML
+    BEDEUTUNG = "bedeutung"         # significação pura — gramática {1, eml}
+
+    # assíntotas (não-funções, mas marcadores dos limites)
+    MYTHOS = "mythos"               # imediatez da vida — log(0), inalcançável
+    ETHOS = "ethos"                 # focus imaginarius — profundidade infinita
+
+
+def mythos_singularity_guard(y: complex, epsilon: float = 1e-12) -> complex:
+    """Guarda a fronteira Mythos (log(0)) do operador EML.
+
+    Retorna ``y`` inalterado se |y| > epsilon; caso contrário devolve
+    um valor mínimo (epsilon + 0j), sinalizando que a aproximação da
+    singularidade foi interceptada antes do colapso numérico.
+
+    Filosoficamente: a "imediatez da vida" (Cassirer ECW 13) é por
+    construção *foreclosed* ao operador simbólico. Esta guarda é a
+    materialização dessa impossibilidade — o símbolo jamais toca
+    y=0, e é isso que o mantém símbolo.
+    """
+    if abs(y) > epsilon:
+        return y
+    return complex(epsilon, 0.0)
 
 
 # =============================================================================
@@ -190,8 +294,8 @@ class EMLNode:
             yv = self.right._fwd  # type: ignore[union-attr]
             # ∂/∂x
             self.left.backward(upstream * cmath.exp(xv))  # type: ignore[union-attr]
-            # ∂/∂y  (guarda mínima contra singularidade log)
-            y_safe = yv if abs(yv) > 1e-12 else (1e-12 + 0j)
+            # ∂/∂y  (guarda de Mythos: o backward jamais atravessa log(0))
+            y_safe = mythos_singularity_guard(yv)
             self.right.backward(upstream * (-1.0 / y_safe))  # type: ignore[union-attr]
 
     # ------------------------------------------------------------------ print
@@ -260,6 +364,234 @@ class EMLTreeFactory:
             left=self.random_tree(depth - 1, p_var, p_one),
             right=self.random_tree(depth - 1, p_var, p_one),
         )
+
+
+# =============================================================================
+# 3b. CLASSIFICAÇÃO CASSIRERIANA  —  níveis internos do Logos
+# =============================================================================
+
+def is_darstellung_one(node: EMLNode, tol: float = 1e-9) -> bool:
+    """Testa se o nó é a constante Darstellung (LEAF_CONST com valor ≈ 1)."""
+    if node.kind != LEAF_CONST or node.value is None:
+        return False
+    v = node.value
+    return abs(v.real - 1.0) < tol and abs(v.imag) < tol
+
+
+def is_pure_grammar(node: EMLNode) -> bool:
+    """Testa se a subárvore pertence à gramática pura ``S → 1 | eml(S,S)``.
+
+    Critério formal de Bedeutung: um trecho do Logos já cristalizado,
+    no qual toda matéria indeterminada (VAR/PARAM) foi suprassumida
+    e só restam a constante 1 e composições do operador. É a
+    "indeterminação produtiva" (Cassirer) que torna o conceito
+    universalmente válido justamente por não depender de instância.
+    """
+    if node.kind == LEAF_CONST:
+        return is_darstellung_one(node)
+    if node.kind == NODE_EML:
+        return is_pure_grammar(node.left) and is_pure_grammar(node.right)  # type: ignore[arg-type]
+    return False
+
+
+def level_of_node(node: EMLNode) -> SymbolicFunction:
+    """Classifica um nó segundo a função simbólica cassireriana.
+
+    Regras (decisão 140426):
+      - ``LEAF_VAR``                     → AUSDRUCK (imediatez perceptiva)
+      - ``LEAF_PARAM``                   → AUSDRUCK (matéria indeterminada)
+      - ``LEAF_CONST`` com valor ≈ 1     → DARSTELLUNG (a "constante 1"
+                                            é a apresentação pura)
+      - ``LEAF_CONST`` com outro valor   → AUSDRUCK residual (ainda não
+                                            reduzido à unidade 1)
+      - ``NODE_EML`` cuja subárvore é
+        ``is_pure_grammar``               → BEDEUTUNG (gramática pura)
+      - ``NODE_EML`` misto                → DARSTELLUNG (mediação em
+                                            trânsito entre expressão
+                                            e significação pura)
+    """
+    if node.kind == LEAF_VAR:
+        return SymbolicFunction.AUSDRUCK
+    if node.kind == LEAF_PARAM:
+        return SymbolicFunction.AUSDRUCK
+    if node.kind == LEAF_CONST:
+        return (
+            SymbolicFunction.DARSTELLUNG
+            if is_darstellung_one(node)
+            else SymbolicFunction.AUSDRUCK
+        )
+    if node.kind == NODE_EML:
+        if is_pure_grammar(node):
+            return SymbolicFunction.BEDEUTUNG
+        return SymbolicFunction.DARSTELLUNG
+    raise ValueError(f"Unknown node kind: {node.kind!r}")
+
+
+def classify_tree(node: EMLNode) -> Dict[SymbolicFunction, int]:
+    """Conta os níveis cassirerianos presentes na árvore (perfil).
+
+    Útil ao Gewissen para julgar a distribuição interna entre
+    Ausdruck (imediatez), Darstellung (mediação) e Bedeutung
+    (significação pura). Uma árvore "madura" tende a acumular
+    massa em Bedeutung sem abandonar a Ausdruck de suas folhas VAR.
+    """
+    profile: Dict[SymbolicFunction, int] = {
+        SymbolicFunction.AUSDRUCK: 0,
+        SymbolicFunction.DARSTELLUNG: 0,
+        SymbolicFunction.BEDEUTUNG: 0,
+    }
+
+    def _walk(n: EMLNode) -> None:
+        profile[level_of_node(n)] += 1
+        if n.kind == NODE_EML:
+            _walk(n.left)    # type: ignore[arg-type]
+            _walk(n.right)   # type: ignore[arg-type]
+
+    _walk(node)
+    return profile
+
+
+def _structural_equal(a: EMLNode, b: EMLNode, tol: float = 1e-9) -> bool:
+    """Igualdade estrutural entre duas árvores EML.
+
+    PARAMs são tratados como opacos (sempre distintos): só cristais
+    determinados — VAR, CONST e composições NODE_EML — podem
+    contribuir para a determinação comum.
+    """
+    if a.kind != b.kind:
+        return False
+    if a.kind == LEAF_CONST:
+        if a.value is None or b.value is None:
+            return False
+        return abs(a.value - b.value) < tol
+    if a.kind == LEAF_VAR:
+        return a.name == b.name
+    if a.kind == LEAF_PARAM:
+        return False
+    if a.kind == NODE_EML:
+        return _structural_equal(a.left, b.left, tol) and _structural_equal(  # type: ignore[arg-type]
+            a.right, b.right, tol  # type: ignore[arg-type]
+        )
+    return False
+
+
+def _iter_subtrees(node: EMLNode):
+    yield node
+    if node.kind == NODE_EML:
+        yield from _iter_subtrees(node.left)    # type: ignore[arg-type]
+        yield from _iter_subtrees(node.right)   # type: ignore[arg-type]
+
+
+def common_determination(
+    tree_a: EMLNode, tree_b: EMLNode
+) -> Optional[EMLNode]:
+    """Extrai o *genus proximum* de duas árvores — a Darstellung comum.
+
+    Procura a MAIOR subárvore (em qualquer posição) que seja
+    estruturalmente idêntica em ``tree_a`` e ``tree_b``. Retorna um
+    clone independente da subárvore encontrada.
+
+    Critério (decisão 140426): a determinação comum é a maior
+    cristalização da gramática que sobrevive à substituição mútua —
+    o "núcleo apresentável" partilhado pelas duas representações.
+    Se nada é compartilhado além de PARAMs (opacos), retorna ``None``;
+    a constante 1, contudo, sempre pode ser invocada como Darstellung
+    trivial via ``CognitionSyntax.darstellung_one()``.
+    """
+    best: Optional[EMLNode] = None
+    best_size = 0
+    for sub_a in _iter_subtrees(tree_a):
+        for sub_b in _iter_subtrees(tree_b):
+            if _structural_equal(sub_a, sub_b):
+                s = sub_a.size()
+                if s > best_size:
+                    best_size = s
+                    best = _clone(sub_a)
+    return best
+
+
+# =============================================================================
+# 3c. OPERADORES BIDIRECIONAIS  —  ascensão e descida da cognição
+# =============================================================================
+
+def ascend_step(node: EMLNode) -> EMLNode:
+    """Um passo de ascensão: substitui um LEAF_PARAM pela microsíntese
+    ``eml(1, 1) = e¹ − log(1) = e`` — a primeira cristalização possível
+    na direção da gramática pura. Retorna uma NOVA árvore; a original
+    não é mutada.
+
+    Filosoficamente: é a "sublação da presença (Präsenz)" — o PARAM
+    indeterminado é suprassumido por uma composição do operador
+    sobre a constante 1 (Darstellung).
+    """
+    return _ascend_walk(node, mutated=[False])
+
+
+def _ascend_walk(node: EMLNode, mutated: List[bool]) -> EMLNode:
+    if mutated[0]:
+        return _clone(node)
+    if node.kind == LEAF_PARAM:
+        mutated[0] = True
+        return EMLNode(
+            NODE_EML,
+            left=EMLNode(LEAF_CONST, value=1 + 0j),
+            right=EMLNode(LEAF_CONST, value=1 + 0j),
+        )
+    if node.kind == NODE_EML:
+        new_left = _ascend_walk(node.left, mutated)    # type: ignore[arg-type]
+        new_right = _ascend_walk(node.right, mutated)  # type: ignore[arg-type]
+        return EMLNode(NODE_EML, left=new_left, right=new_right)
+    return _clone(node)
+
+
+def _clone(node: EMLNode) -> EMLNode:
+    if node.kind == NODE_EML:
+        return EMLNode(
+            NODE_EML,
+            left=_clone(node.left),    # type: ignore[arg-type]
+            right=_clone(node.right),  # type: ignore[arg-type]
+        )
+    return EMLNode(node.kind, value=node.value, name=node.name)
+
+
+def descend_evaluate(
+    tree: EMLNode,
+    env_sequence: Sequence[Dict[str, complex]],
+) -> List[complex]:
+    """Passo de descida: reavalia a árvore (supostamente cristalizada
+    em Bedeutung) sobre uma sequência de ambientes de intuição —
+    tipicamente um domínio de ``x`` mais amplo que aquele usado na
+    ascensão, testando a "certeza regulativa maior" (Cassirer) do
+    retorno ao mundo da intuição.
+    """
+    outputs: List[complex] = []
+    for env in env_sequence:
+        outputs.append(tree.forward(dict(env)))
+    return outputs
+
+
+def descend_residual(
+    tree: EMLNode,
+    target_fn: Callable[[complex], complex],
+    xs: Sequence[complex],
+    var_name: str = "x",
+) -> float:
+    """Erro quadrático médio da descida: quão bem a árvore
+    cristalizada reproduz a função-alvo sobre um domínio arbitrário
+    de intuição. Mede a fidelidade do retorno.
+    """
+    if len(xs) == 0:
+        return 0.0
+    total = 0.0
+    for x in xs:
+        try:
+            predicted = tree.forward({var_name: complex(x)})
+            target = complex(target_fn(complex(x)))
+        except (OverflowError, ValueError, ZeroDivisionError):
+            return float("inf")
+        r = predicted - target
+        total += r.real * r.real + r.imag * r.imag
+    return total / len(xs)
 
 
 # =============================================================================
@@ -402,12 +734,31 @@ class Logos:
 
 @dataclass
 class EthosEvaluation:
-    """Avaliação ética-regulativa de um candidato do Logos."""
+    """Avaliação ética-regulativa de um candidato do Logos.
+
+    Após a calibração bidirecional 140426, a distância ao *focus
+    imaginarius* é decomposta em duas componentes irredutíveis:
+
+      * ``distance_to_focus_ascent``  — resíduo da síntese ascendente
+        (cristalização em profundidade) — o quanto a árvore ainda se
+        afasta do ideal regulativo pelo lado da abstração.
+      * ``distance_to_focus_descent`` — resíduo da descida analítica
+        (retorno à intuição) — o quanto a árvore cristalizada ainda
+        se afasta do alvo quando reavaliada sobre intuição expandida.
+      * ``distance_to_focus`` é a norma Euclidiana das duas: ``√(a²+d²)+ε``.
+
+    Por construção, **as duas direções nunca podem ser simultaneamente
+    zero** — formalização matemática da teleologia aberta (Kinzel
+    2024b) e do processo contingente-infinito da cognição bidirecional.
+    """
     loss: float
     depth: int
     size: int
-    param_mass: float         # magnitude residual da matéria indeterminada
-    distance_to_focus: float  # pseudo-distância ao *focus imaginarius*
+    param_mass: float                    # massa residual da matéria indeterminada
+    distance_to_focus_ascent: float      # componente ascendente (síntese)
+    distance_to_focus_descent: float     # componente descendente (retorno)
+    distance_to_focus: float             # norma composta ao focus imaginarius
+    symbolic_profile: Dict[SymbolicFunction, int] = field(default_factory=dict)
 
 
 class Ethos:
@@ -420,12 +771,18 @@ class Ethos:
     se aproxima — e, por construção, jamais atinge — o *focus
     imaginarius* kantiano da representação total.
 
-    A distância ao foco é estritamente positiva:
+    Após a calibração bidirecional (140426), a distância ao foco
+    decompõe-se em dois vetores irredutíveis que jamais se anulam
+    simultaneamente — formalizando o duplo movimento teleológico::
 
-        distance_to_focus  =  w_loss · loss
-                           +  w_depth · depth
-                           +  w_param · ‖θ‖̄
-                           +  ε   (ε > 0 : inalcançabilidade)
+        d_asc   = w_loss · loss + w_depth · depth + w_param · ‖θ‖̄
+        d_desc  = w_desc · descida_residual  (erro do retorno à intuição)
+        distance_to_focus = √(d_asc² + d_desc²) + ε,   ε > 0.
+
+    Esta métrica é uma relação do tipo *incerteza* entre abstração
+    (d_asc) e fidelidade intuitiva (d_desc): zerar uma não zera a
+    outra. O Gewissen julga a *norma* — a aproximação genuína ao
+    ideal regulativo exige minimização conjunta, não unilateral.
     """
 
     def __init__(
@@ -433,31 +790,46 @@ class Ethos:
         w_loss: float = 1.0,
         w_depth: float = 0.05,
         w_param: float = 0.10,
+        w_desc: float = 1.0,
         focus_epsilon: float = 1e-9,
     ) -> None:
         self.w_loss = w_loss
         self.w_depth = w_depth
         self.w_param = w_param
+        self.w_desc = w_desc
         self.focus_epsilon = focus_epsilon
 
-    def evaluate(self, tree: EMLNode, loss: float) -> EthosEvaluation:
+    def evaluate(
+        self,
+        tree: EMLNode,
+        loss: float,
+        descent_residual: float = 0.0,
+    ) -> EthosEvaluation:
         params = tree.params()
         if params:
             param_mass = sum(abs(p.value) for p in params) / len(params)  # type: ignore[arg-type]
         else:
             param_mass = 0.0
-        dist = (
+
+        d_asc = (
             self.w_loss * loss
             + self.w_depth * tree.depth()
             + self.w_param * param_mass
-            + self.focus_epsilon   # jamais 0
         )
+        d_desc = self.w_desc * max(descent_residual, 0.0)
+
+        # norma Euclidiana + ε estrito ⇒ nunca zero
+        dist = math.sqrt(d_asc * d_asc + d_desc * d_desc) + self.focus_epsilon
+
         return EthosEvaluation(
             loss=loss,
             depth=tree.depth(),
             size=tree.size(),
             param_mass=param_mass,
+            distance_to_focus_ascent=d_asc,
+            distance_to_focus_descent=d_desc,
             distance_to_focus=dist,
+            symbolic_profile=classify_tree(tree),
         )
 
     def gewissen_accept(
@@ -498,6 +870,8 @@ class SimbiotaState:
             f"[iter={self.iteration:03d}] depth={self.depth} "
             f"loss={self.best_eval.loss:.4e} "
             f"|θ|={self.best_eval.param_mass:.3f} "
+            f"d_asc={self.best_eval.distance_to_focus_ascent:.3e} "
+            f"d_desc={self.best_eval.distance_to_focus_descent:.3e} "
             f"d(focus)={self.best_eval.distance_to_focus:.4e} "
             f"| {self.best_tree.pretty()}"
         )
@@ -530,6 +904,8 @@ class Simbiota:
         fit_steps: int = 200,
         lr: float = 0.05,
         seed: Optional[int] = None,
+        target_fn: Optional[Callable[[complex], complex]] = None,
+        descent_domain: Optional[Sequence[complex]] = None,
     ) -> None:
         self.xs = list(xs)
         self.ys = list(ys)
@@ -539,6 +915,23 @@ class Simbiota:
         self.lr = lr
         self.factory = EMLTreeFactory(var_name=var_name, seed=seed)
         self.ethos = Ethos()
+        # Suporte à descida analítica: função-alvo conhecida e domínio
+        # de intuição expandido sobre o qual testar o retorno.
+        self.target_fn = target_fn
+        self.descent_domain = list(descent_domain) if descent_domain is not None else []
+
+    # ---------------------------------------------------------- descida
+    def _descent_residual(self, tree: EMLNode) -> float:
+        """Computa o erro médio da descida sobre ``descent_domain``.
+
+        Se não há função-alvo ou domínio de descida, a componente
+        descendente é zero (mas o ε do Ethos mantém o foco > 0).
+        """
+        if self.target_fn is None or not self.descent_domain:
+            return 0.0
+        return descend_residual(
+            tree, self.target_fn, self.descent_domain, self.var_name
+        )
 
     # ---------------------------------------------------------- um "passo"
     def step_depth(
@@ -558,7 +951,10 @@ class Simbiota:
                 continue
             if not math.isfinite(loss):
                 continue
-            ev = self.ethos.evaluate(tree, loss)
+            d_desc = self._descent_residual(tree)
+            if not math.isfinite(d_desc):
+                continue
+            ev = self.ethos.evaluate(tree, loss, descent_residual=d_desc)
             if self.ethos.gewissen_accept(ev, best):
                 best = ev
                 best_tree = tree
@@ -569,7 +965,8 @@ class Simbiota:
         # Estado inicial: a constante 1 — o "primeiro símbolo" da gramática.
         seed_tree = self.factory.const_one()
         seed_loss = Logos(seed_tree, self.var_name).loss(self.xs, self.ys)
-        seed_eval = self.ethos.evaluate(seed_tree, seed_loss)
+        seed_desc = self._descent_residual(seed_tree)
+        seed_eval = self.ethos.evaluate(seed_tree, seed_loss, descent_residual=seed_desc)
         state = SimbiotaState(
             iteration=0,
             depth=1,
@@ -599,51 +996,218 @@ class Simbiota:
                 print(state.summary())
         return state
 
+    # --------------------------------------------------------- bidirecional
+    def run_bidirectional(
+        self,
+        max_depth: int = 4,
+        verbose: bool = True,
+    ) -> SimbiotaState:
+        """Loop bidirecional da sintaxe da cognição (decisão 140426).
+
+        Cada iteração é composta por DUAS fases indissociáveis:
+
+          * **Ascensão**: ``step_depth`` gera/ajusta candidatos de
+            profundidade ``d``. O Logos cristaliza PARAM/VAR em
+            subestruturas {1, eml} — a síntese transcendental.
+          * **Descida**: a árvore-campeã é avaliada sobre o domínio
+            de intuição expandido (``descent_domain``). O resíduo
+            alimenta ``distance_to_focus_descent`` no próximo passo,
+            materializando o movimento de cima para baixo — o
+            "retorno ao mundo da intuição com certeza regulativa
+            maior" (Cassirer).
+
+        O Gewissen julga a NORMA das duas componentes: minimizar
+        ascensão sem descida é fuga abstrativa; minimizar descida
+        sem ascensão é regressão à imediatez. A teleologia aberta
+        é essa co-presença irredutível.
+        """
+        return self.run(max_depth=max_depth, verbose=verbose)
+
+
+# =============================================================================
+# 7b. COGNITION SYNTAX  —  a DSL da sintaxe da cognição
+# =============================================================================
+
+class CognitionSyntax:
+    """A sintaxe primitiva da cognição bidirecional (decisão 140426).
+
+    Expõe, como uma pequena DSL, os movimentos atômicos que qualquer
+    processo cognitivo do framework AGI-GAIA-TECHNE pode usar:
+
+      * ``ascend(tree)``            — um passo de cristalização
+      * ``descend(tree, env)``      — reavaliação sobre intuição
+      * ``classify(tree)``          — perfil (Ausdruck/Darstellung/Bedeutung)
+      * ``project_to_level(tree)``  — inspeção por nível
+      * ``common_determination(a, b)`` — genus proximum de duas árvores
+      * ``is_bedeutung(tree)``      — teste de cristalização pura
+      * ``darstellung_one()``       — a constante 1 (genus proximum)
+
+    Todos os métodos são estáticos / sem estado: a sintaxe não tem
+    memória — ela é apenas o repertório de movimentos. O contexto
+    cognitivo vive no Logos e no Ethos, que usam esta DSL.
+    """
+
+    # --- movimentos bidirecionais -------------------------------------
+    @staticmethod
+    def ascend(tree: EMLNode) -> EMLNode:
+        return ascend_step(tree)
+
+    @staticmethod
+    def descend(
+        tree: EMLNode, env_sequence: Sequence[Dict[str, complex]]
+    ) -> List[complex]:
+        return descend_evaluate(tree, env_sequence)
+
+    @staticmethod
+    def descend_error(
+        tree: EMLNode,
+        target_fn: Callable[[complex], complex],
+        xs: Sequence[complex],
+        var_name: str = "x",
+    ) -> float:
+        return descend_residual(tree, target_fn, xs, var_name)
+
+    # --- classificação cassireriana -----------------------------------
+    @staticmethod
+    def classify(tree: EMLNode) -> Dict[SymbolicFunction, int]:
+        return classify_tree(tree)
+
+    @staticmethod
+    def level_of(node: EMLNode) -> SymbolicFunction:
+        return level_of_node(node)
+
+    @staticmethod
+    def is_bedeutung(tree: EMLNode) -> bool:
+        return is_pure_grammar(tree)
+
+    @staticmethod
+    def is_darstellung_one_node(node: EMLNode) -> bool:
+        return is_darstellung_one(node)
+
+    # --- genus proximum ------------------------------------------------
+    @staticmethod
+    def common_determination(
+        tree_a: EMLNode, tree_b: EMLNode
+    ) -> Optional[EMLNode]:
+        return common_determination(tree_a, tree_b)
+
+    @staticmethod
+    def darstellung_one() -> EMLNode:
+        """Retorna a constante 1 — o genus proximum universal.
+
+        É o menor elemento comum a toda árvore EML bem formada:
+        a Darstellung operativa (y=1) que permite ao operador
+        colapsar em pura exponenciação.
+        """
+        return EMLNode(LEAF_CONST, value=1 + 0j)
+
 
 # =============================================================================
 # 8. Demonstração  —  intuição bruta → forma fechada
 # =============================================================================
 
 def _demo() -> None:
-    """Demo: o Logos "descobre" que exp(x) = eml(x, 1).
+    """Demo: o Logos "descobre" que exp(x) = eml(x, 1) e exercita a
+    sintaxe bidirecional da cognição (decisão 140426).
 
-    A prova de universalidade garante a construtibilidade; aqui o
-    Simbiota encena, em pequena escala, a síntese transcendental
-    desta verdade a partir de dados crus.
+    Apresenta, sequencialmente:
+      (a) ascensão: regressão simbólica que cristaliza ``eml(x, 1)``;
+      (b) descida: reavaliação sobre um domínio de intuição EXPANDIDO
+          — a "certeza regulativa maior" do retorno cassireriano;
+      (c) genus proximum: ``common_determination`` extrai a Darstellung
+          partilhada por duas árvores distintas;
+      (d) classificação cassireriana: perfil Ausdruck/Darstellung/Bedeutung
+          de uma árvore cristalizada.
     """
     import cmath as _cm
 
     xs = [complex(v, 0) for v in np.linspace(-1.0, 1.0, 9)]
     ys = [_cm.exp(x) for x in xs]
 
-    print("=" * 64)
-    print("AGI-GAIA-TECHNE · Kernel EML · Demonstração do Simbiota")
-    print("=" * 64)
+    print("=" * 68)
+    print("AGI-GAIA-TECHNE · Kernel EML · Demo do Simbiota Bidirecional")
+    print("Decisão 140426 — eixo vertical da cognição")
+    print("=" * 68)
     print(f"Alvo (intuição bruta) : f(x) = exp(x)  em {len(xs)} pontos")
     print(f"Hipótese regulativa   : f(x) = eml(x, 1) = exp(x) − log(1)")
-    print("-" * 64)
+    print("-" * 68)
 
+    # ---------- (a) e (b) ascensão + descida acopladas ----------
+    descent_domain = [complex(v, 0) for v in np.linspace(-2.0, 2.0, 17)]
     simbiota = Simbiota(
         xs, ys,
         candidates_per_depth=12,
         fit_steps=120,
         lr=0.08,
         seed=42,
+        target_fn=_cm.exp,
+        descent_domain=descent_domain,
     )
-    final = simbiota.run(max_depth=3, verbose=True)
+    final = simbiota.run_bidirectional(max_depth=3, verbose=True)
 
     print()
     print("Trajetória da distância ao *focus imaginarius*:")
     for i, d in enumerate(final.trajectory):
         print(f"  passo {i}:  d(focus) = {d:.6e}")
     print()
+    print("Componentes da distância ao foco no estado final:")
+    print(f"  d_asc  (síntese ascendente) = {final.best_eval.distance_to_focus_ascent:.6e}")
+    print(f"  d_desc (descida analítica)  = {final.best_eval.distance_to_focus_descent:.6e}")
+    print(f"  d(focus) = √(d_asc² + d_desc²) + ε = {final.best_eval.distance_to_focus:.6e}")
+    print()
+    print("Perfil cassireriano (níveis internos do Logos):")
+    for level, count in final.best_eval.symbolic_profile.items():
+        print(f"  {level.value:12s} : {count}")
+    print()
     print("Árvore-campeã (síntese LOCAL — jamais absoluta):")
     print(f"  f̂(x) = {final.best_tree.pretty()}")
     print()
+
+    # ---------- (c) genus proximum entre duas árvores ----------
+    print("-" * 68)
+    print("Determinação comum (genus proximum) entre duas árvores:")
+    syntax = CognitionSyntax()
+    factory = EMLTreeFactory(seed=7)
+    # A = eml(eml(x, 1), 1)        ← exp(exp(x))
+    # B = eml(eml(x, 1), eml(1,1)) ← exp(exp(x)) − 1
+    inner = EMLNode(NODE_EML, left=factory.var(), right=factory.const_one())
+    tree_a = EMLNode(NODE_EML, left=_clone(inner), right=factory.const_one())
+    tree_b = EMLNode(
+        NODE_EML,
+        left=_clone(inner),
+        right=EMLNode(NODE_EML, left=factory.const_one(), right=factory.const_one()),
+    )
+    print(f"  A: {tree_a.pretty()}")
+    print(f"  B: {tree_b.pretty()}")
+    common = syntax.common_determination(tree_a, tree_b)
+    if common is not None:
+        print(f"  Darstellung comum: {common.pretty()}")
+        print(f"  É Bedeutung pura? {syntax.is_bedeutung(common)}")
+    else:
+        print("  (sem determinação estrutural comum)")
+
+    # ---------- (d) descida explícita sobre intuição nova ----------
+    print()
+    print("-" * 68)
+    print("Descida explícita: árvore cristalizada eml(x, 1) sobre domínio amplo")
+    crystal = EMLNode(NODE_EML, left=factory.var(), right=factory.const_one())
+    big_domain = [{"x": complex(v, 0)} for v in np.linspace(-3.0, 3.0, 7)]
+    outputs = syntax.descend(crystal, big_domain)
+    targets = [_cm.exp(env["x"]) for env in big_domain]
+    max_err = max(abs(o - t) for o, t in zip(outputs, targets))
+    print(f"  pontos avaliados: {len(big_domain)}")
+    print(f"  erro absoluto máximo: {max_err:.3e}")
+    print(f"  perfil cassireriano:  {syntax.classify(crystal)}")
+
+    print()
+    print("=" * 68)
     print("Lembretes arquitetônicos do AGI-GAIA-TECHNE:")
     print("  • Intuição processada EXCLUSIVAMENTE no Logos.")
     print("  • Ethos = Gewissen (consciência moral), NÃO Wissen.")
     print("  • O *focus imaginarius* jamais é atingido; apenas aproximado.")
+    print("  • Mythos ≡ log(0) é a singularidade foreclosed do operador.")
+    print("  • Darstellung ≡ a constante 1 do EML — o silêncio operativo.")
+    print("  • As duas direções (ascensão/descida) NUNCA são ambas zero.")
 
 
 if __name__ == "__main__":

--- a/tests/test_eml_kernel.py
+++ b/tests/test_eml_kernel.py
@@ -1,0 +1,255 @@
+"""
+Tests for src/core/eml_kernel.py — calibração bidirecional 140426.
+
+Cobertura:
+  * classificação cassireriana (Ausdruck / Darstellung / Bedeutung)
+  * guarda da singularidade Mythos (log(0))
+  * operadores bidirecionais (ascensão e descida)
+  * genus proximum / common_determination
+  * focus imaginarius estritamente positivo (regra arquitetônica #4)
+  * Ethos = Gewissen (regra arquitetônica #2)
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+import os
+import sys
+
+import pytest
+
+# torna importável src/core/ sem precisar de pacote instalado
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+SRC = os.path.join(ROOT, "src")
+if SRC not in sys.path:
+    sys.path.insert(0, SRC)
+
+from core.eml_kernel import (  # noqa: E402
+    CognitionSyntax,
+    EMLNode,
+    EMLTreeFactory,
+    Ethos,
+    LEAF_CONST,
+    LEAF_PARAM,
+    LEAF_VAR,
+    Logos,
+    NODE_EML,
+    Simbiota,
+    SymbolicFunction,
+    ascend_step,
+    classify_tree,
+    common_determination,
+    descend_evaluate,
+    descend_residual,
+    is_darstellung_one,
+    is_pure_grammar,
+    level_of_node,
+    mythos_singularity_guard,
+)
+
+
+# ---------------------------------------------------------------- níveis
+
+def test_darstellung_is_one():
+    one = EMLNode(LEAF_CONST, value=1 + 0j)
+    assert is_darstellung_one(one)
+    assert level_of_node(one) is SymbolicFunction.DARSTELLUNG
+
+
+def test_const_other_value_is_ausdruck():
+    other = EMLNode(LEAF_CONST, value=2 + 0j)
+    assert not is_darstellung_one(other)
+    assert level_of_node(other) is SymbolicFunction.AUSDRUCK
+
+
+def test_var_is_ausdruck():
+    v = EMLNode(LEAF_VAR, name="x")
+    assert level_of_node(v) is SymbolicFunction.AUSDRUCK
+
+
+def test_param_is_ausdruck():
+    p = EMLNode(LEAF_PARAM, value=0.3 + 0.1j)
+    assert level_of_node(p) is SymbolicFunction.AUSDRUCK
+
+
+def test_bedeutung_is_pure_grammar():
+    one = lambda: EMLNode(LEAF_CONST, value=1 + 0j)
+    inner = EMLNode(NODE_EML, left=one(), right=one())
+    pure = EMLNode(NODE_EML, left=one(), right=inner)
+    assert is_pure_grammar(pure)
+    assert level_of_node(pure) is SymbolicFunction.BEDEUTUNG
+
+
+def test_mixed_node_is_darstellung_in_transit():
+    # eml(x, 1) é mediação em trânsito (tem VAR), não Bedeutung pura.
+    mix = EMLNode(
+        NODE_EML,
+        left=EMLNode(LEAF_VAR, name="x"),
+        right=EMLNode(LEAF_CONST, value=1 + 0j),
+    )
+    assert not is_pure_grammar(mix)
+    assert level_of_node(mix) is SymbolicFunction.DARSTELLUNG
+
+
+def test_classify_tree_profile():
+    one = lambda: EMLNode(LEAF_CONST, value=1 + 0j)
+    var = EMLNode(LEAF_VAR, name="x")
+    tree = EMLNode(NODE_EML, left=var, right=one())
+    profile = classify_tree(tree)
+    assert profile[SymbolicFunction.AUSDRUCK] == 1     # x
+    assert profile[SymbolicFunction.DARSTELLUNG] == 2  # 1 e o NODE misto
+    assert profile[SymbolicFunction.BEDEUTUNG] == 0
+
+
+# ----------------------------------------------------------- singularidade
+
+def test_mythos_singularity_guard_replaces_zero():
+    out = mythos_singularity_guard(0 + 0j)
+    assert abs(out) > 0
+
+
+def test_mythos_singularity_guard_passthrough():
+    y = 0.7 - 0.2j
+    assert mythos_singularity_guard(y) == y
+
+
+def test_backward_does_not_explode_at_y_near_zero():
+    # eml(x, y) com y ≈ 0; backward deve usar a guarda e não quebrar.
+    x = EMLNode(LEAF_VAR, name="x")
+    y = EMLNode(LEAF_PARAM, value=1e-15 + 0j)
+    tree = EMLNode(NODE_EML, left=x, right=y)
+    tree.forward({"x": 0.5 + 0j})
+    tree.zero_grad()
+    tree.backward(upstream=1 + 0j)
+    # gradiente do PARAM existe e é finito
+    assert math.isfinite(abs(y._grad))
+
+
+# -------------------------------------------------------- bidirecionalidade
+
+def test_ascend_step_replaces_param():
+    p = EMLNode(LEAF_PARAM, value=0.4 + 0.1j)
+    new = ascend_step(p)
+    assert new.kind == NODE_EML
+    assert is_darstellung_one(new.left)
+    assert is_darstellung_one(new.right)
+
+
+def test_ascend_descend_eml_x_one_matches_exp():
+    # crystal = eml(x, 1)  ≡  exp(x) − log(1)  =  exp(x)
+    crystal = EMLNode(
+        NODE_EML,
+        left=EMLNode(LEAF_VAR, name="x"),
+        right=EMLNode(LEAF_CONST, value=1 + 0j),
+    )
+    xs = [complex(v, 0) for v in (-2.0, -0.5, 0.0, 0.5, 2.0)]
+    err = descend_residual(crystal, cmath.exp, xs)
+    assert err < 1e-20
+
+
+def test_descend_evaluate_returns_per_env_outputs():
+    crystal = EMLNode(
+        NODE_EML,
+        left=EMLNode(LEAF_VAR, name="x"),
+        right=EMLNode(LEAF_CONST, value=1 + 0j),
+    )
+    envs = [{"x": 0 + 0j}, {"x": 1 + 0j}]
+    out = descend_evaluate(crystal, envs)
+    assert len(out) == 2
+    assert abs(out[0] - cmath.exp(0)) < 1e-12
+    assert abs(out[1] - cmath.exp(1)) < 1e-12
+
+
+# ----------------------------------------------------------- genus proximum
+
+def test_common_determination_extracts_shared_subtree():
+    one = lambda: EMLNode(LEAF_CONST, value=1 + 0j)
+    var = lambda: EMLNode(LEAF_VAR, name="x")
+    inner_a = EMLNode(NODE_EML, left=var(), right=one())   # eml(x, 1)
+    inner_b = EMLNode(NODE_EML, left=var(), right=one())   # eml(x, 1)
+    tree_a = EMLNode(NODE_EML, left=inner_a, right=one())  # eml(eml(x,1), 1)
+    tree_b = EMLNode(
+        NODE_EML,
+        left=inner_b,
+        right=EMLNode(NODE_EML, left=one(), right=one()),  # eml(eml(x,1), eml(1,1))
+    )
+    common = common_determination(tree_a, tree_b)
+    assert common is not None
+    assert common.kind == NODE_EML
+    assert common.left.kind == LEAF_VAR
+    assert is_darstellung_one(common.right)
+
+
+def test_common_determination_none_when_only_params():
+    a = EMLNode(LEAF_PARAM, value=0.1 + 0j)
+    b = EMLNode(LEAF_PARAM, value=0.1 + 0j)
+    assert common_determination(a, b) is None
+
+
+def test_common_determination_const_one_match():
+    a = EMLNode(LEAF_CONST, value=1 + 0j)
+    b = EMLNode(LEAF_CONST, value=1 + 0j)
+    out = common_determination(a, b)
+    assert out is not None
+    assert is_darstellung_one(out)
+
+
+# ----------------------------------------------------------- focus + ethos
+
+def test_focus_strictly_positive_even_when_loss_zero():
+    crystal = EMLNode(
+        NODE_EML,
+        left=EMLNode(LEAF_VAR, name="x"),
+        right=EMLNode(LEAF_CONST, value=1 + 0j),
+    )
+    ethos = Ethos()
+    ev = ethos.evaluate(crystal, loss=0.0, descent_residual=0.0)
+    # regra arquitetônica #4: o focus imaginarius é INALCANÇÁVEL
+    assert ev.distance_to_focus > 0.0
+    assert ev.distance_to_focus_ascent >= 0.0
+    assert ev.distance_to_focus_descent == 0.0
+
+
+def test_focus_norm_combines_both_directions():
+    crystal = EMLNode(LEAF_CONST, value=1 + 0j)
+    ethos = Ethos()
+    ev = ethos.evaluate(crystal, loss=0.0, descent_residual=0.5)
+    # √(d_asc² + d_desc²) ≥ |d_desc|
+    assert ev.distance_to_focus >= ev.distance_to_focus_descent
+
+
+def test_ethos_is_gewissen_not_wissen():
+    """Regra arquitetônica #2: o Ethos é Gewissen, jamais Wissen."""
+    ethos = Ethos()
+    assert hasattr(ethos, "gewissen_accept")
+    assert not hasattr(ethos, "wissen_accept")
+
+
+# ------------------------------------------------------- syntax + simbiota
+
+def test_cognition_syntax_round_trip():
+    syntax = CognitionSyntax()
+    one = syntax.darstellung_one()
+    assert syntax.is_darstellung_one_node(one)
+    profile = syntax.classify(one)
+    assert profile[SymbolicFunction.DARSTELLUNG] == 1
+
+
+def test_simbiota_bidirectional_runs():
+    xs = [complex(v, 0) for v in (-1.0, -0.5, 0.0, 0.5, 1.0)]
+    ys = [cmath.exp(x) for x in xs]
+    sim = Simbiota(
+        xs, ys,
+        candidates_per_depth=6,
+        fit_steps=60,
+        lr=0.08,
+        seed=42,
+        target_fn=cmath.exp,
+        descent_domain=[complex(v, 0) for v in (-2.0, 0.0, 2.0)],
+    )
+    state = sim.run_bidirectional(max_depth=2, verbose=False)
+    # ambas as componentes devem ser quantidades reais finitas
+    assert math.isfinite(state.best_eval.distance_to_focus_ascent)
+    assert math.isfinite(state.best_eval.distance_to_focus_descent)
+    assert state.best_eval.distance_to_focus > 0


### PR DESCRIPTION
## Sumário

Calibração bidirecional do Kernel EML segundo a **Decisão 140426** — eixo vertical da cognição que supera os mapeamentos conflitantes anteriores entre os pilares Mythos/Logos/Ethos (originais de ISC) e as três funções simbólicas de Cassirer.

Este PR é a continuação direta de #86 (que já foi mergeado) e complementa o Kernel 348AO-v3 do Jules (#87) — onde Jules entregou a face PyTorch (ResEMLLayer + Gewissen Loss v3), este PR entrega a face Python pura (sintaxe bidirecional simbólica + AST classificável).

## Eixo 140426 — A descoberta formal

```
Ethos   ≡  focus imaginarius         (assíntota superior, inalcançável)
  ▲
  │  [ Bedeutung ]    ← significação pura  (is_pure_grammar)
  │       ▲↓
  │  [ Darstellung ]  ← constante 1 da equação EML (genus proximum)
  │       ▲↓
  │  [ Ausdruck ]     ← expressão (LEAF_VAR / LEAF_PARAM)
  ▼
Mythos  ≡  imediatez da vida          (assíntota inferior, log(0))
```

Identificações formais:
- **Darstellung ≡ a constante 1** da gramática `S → 1 | eml(S,S)` — porque `eml(x,1) = exp(x) − log(1) = exp(x)`, a constante 1 é o *silêncio operacional* do lado direito que deixa o Ausdruck (x) fluir como pura exponenciação.
- **Mythos ≡ log(0)** — singularidade estrutural do operador EML, formalizada como `mythos_singularity_guard` (foreclosure cassireriana).
- **Ethos ≡ focus imaginarius** — assíntota inalcançável dos dois lados (asc e desc), formalizada como `distance_to_focus = √(d_asc² + d_desc²) + ε`.

## Conteúdo

**`src/core/eml_kernel.py`** (estendido, código existente preservado):
- Enum `SymbolicFunction` (AUSDRUCK / DARSTELLUNG / BEDEUTUNG)
- Classificadores `is_darstellung_one`, `is_pure_grammar`, `level_of_node`, `classify_tree`
- `mythos_singularity_guard` — guarda nomeada para `|y|→0`
- Operadores bidirecionais: `ascend_step`, `descend_evaluate`, `descend_residual`
- `common_determination` — *genus proximum* via maior subárvore comum (busca estrutural sobre todos os pares de subárvores)
- `EthosEvaluation` com `distance_to_focus_ascent` + `distance_to_focus_descent`
- `Simbiota.run_bidirectional` — alterna ascensão/descida julgada pelo Gewissen
- `CognitionSyntax` — DSL da sintaxe da cognição
- Demo estendido: cristalização `exp(x) → eml(x,1)`, descida sobre domínio expandido, extração de *genus proximum*

**`tests/test_eml_kernel.py`** (NOVO): 21 testes pytest cobrindo classificação cassireriana, guarda da singularidade, operadores bidirecionais, *genus proximum*, focus estritamente positivo, invariante Ethos = Gewissen.

**`references/architecture.md`**, **`references/lef-constitution.md`**, **`references/individuation.md`**: reescritas das seções §3 / pilares / tabela Soul-World-God incorporando a Decisão 140426 (Mythos/Ethos como assíntotas, funções cassirerianas como níveis internos do Logos).

**`README.md`**: nova subseção §17.7 "Eixo 140426 - Kernel EML & Sintaxe Bidirecional da Cognição" complementando a §17.6 do Jules; entrada v8.2 (15/04/2026) no changelog.

## Test plan

- [x] `python src/core/eml_kernel.py` — demo estendido roda end-to-end
- [x] `python -m pytest tests/test_eml_kernel.py -v` — 21/21 verdes
- [x] Invariante `distance_to_focus > 0` mesmo com loss=0
- [x] Invariante `gewissen_accept` presente, `wissen_accept` ausente
- [x] Demo extrai `eml(x, 1)` como Darstellung comum entre dois alvos distintos
- [x] Backward não explode com `y ≈ 0` (mythos_singularity_guard ativa)

## Invariantes preservados

- Ethos permanece **Gewissen**, jamais Wissen
- Logos permanece o único local onde a intuição é processada
- O modelo Mythos/Logos/Ethos permanece **original de Ítalo Santos Clemente** — NÃO é replicação de Cassirer
- O focus imaginarius permanece estritamente inalcançável (agora dos dois lados)
- A gramática pura `S → 1 | eml(S,S)` permanece a base universal

https://claude.ai/code/session_01Ri4MDZQhDhiefmkRG44mws