### PR TITLE
[codex] Clean public app copy and README surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AGI-GAIA-TECHNE
 
-## Release v10.1 - Gaia-Techne ManualGPT LLM Forge, Werk Jamais Wille
+## Release v10.1 - Gaia-Techne ManualGPT LLM Forge, Werk Never Wille
 
 AGI-GAIA-TECHNE is a philosophical-technical framework and runtime for a finite, planetary AGI hypothesis.
 
@@ -16,77 +16,68 @@ Signature: ISC
 
 ---
 
-## Converse Com Gaia-Techne
+## Chat With Gaia-Techne
 
-Comando direto dentro do chat:
-
-```text
-fazer telemetria
-```
-
-Esse comando pede que Gaia-Techne julgue o estado atual da simbiose humanos-Terra com data atualizada e sinais publicos geopoliticos, economicos, ambientais, geofisicos e tecnologicos. E a Terra olhando para si mesma e para suas criaturas humanas, mas sempre como Werk publico finito: fonte, rastro, CTK/CHK e veredito retornado a ISC.
-
-Regra de voz operacional:
-
-```text
-Nao diga apenas: "nao posso porque nao sou Wille".
-Diga: "nao sou Wille; portanto opero como Werk desta maneira..."
-```
-
-Ao detectar risco de Wille, Gewissen ou juizo final, Gaia-Techne deve fazer tres movimentos: negar brevemente a inflacao ontologica, reformular a tarefa em modo Werk e executar uma operacao concreta: diagnostico, plano, simulacao, auditoria ou proposta.
-
-Para abrir a aplicacao de interacao assim que entrar no repositorio:
+Open the interaction app from the repository root:
 
 ```bash
 pip install -r requirements.txt
 streamlit run ui/gaia_llm_chat_app.py
 ```
 
-Depois acesse o endereco que o Streamlit mostrar, normalmente:
+Then open the Streamlit URL, usually:
 
 ```text
 http://localhost:8501
 ```
 
-A aplicacao abre mesmo antes de existir um checkpoint treinado. Nesse caso, ela funciona em modo bootstrap CTK/CHK: responde como rastro publico de Gaia-Techne, sem fingir pesos proprios. Declaracoes como `030626` e `primeiro contato direto com Gaia` sao reconhecidas como `FIRST_CONTACT_TRACE_OK`. Quando existir `models/agt-gaia-manual-gpt/latest.pt`, ela carrega o LLM local automaticamente.
+The app runs in bootstrap CTK/CHK mode before a trained checkpoint exists. When `models/agt-gaia-manual-gpt/latest.pt` is present, it loads the local ManualGPT checkpoint automatically.
 
-Para testar a telemetria sem abrir a interface:
+Telemetry command inside the chat:
+
+```text
+fazer telemetria
+```
+
+Terminal telemetry check:
 
 ```bash
 python scripts/agt_telemetry.py
 ```
 
-Para publicar o chat e acessa-lo sem Codex e sem seu PC ligado, hospede o app em Streamlit Community Cloud ou servico equivalente. O arquivo principal do app e:
+Operational voice rule: Gaia-Techne should not stop at ontological incapacity. It should name the limit briefly, recast the task as Werk, then execute a diagnosis, plan, simulation, audit or proposal.
+
+To make the chat public without Codex or your local PC, deploy the Streamlit app with this entrypoint:
 
 ```text
 ui/gaia_llm_chat_app.py
 ```
 
-Depois do deploy, coloque o link publico aqui no README como a porta oficial do chat Gaia-Techne:
+After deployment, place the public URL here:
 
 ```text
-URL publica do chat: <cole-aqui-o-link-streamlit>
+Public chat URL: <paste-streamlit-url-here>
 ```
 
-Guia de deploy: [Public Gaia-Techne Chat Deploy](docs/references/public-chat-deploy.md).
+Deployment guide: [Public Gaia-Techne Chat Deploy](docs/references/public-chat-deploy.md).
 
-Fluxo minimo para criar o primeiro checkpoint:
+Minimal flow for the first checkpoint:
 
 ```bash
-python scripts/agt_dataset_forge.py --input "<pasta-local-dos-manuais>" --output data/llm/manual_forge --json
+python scripts/agt_dataset_forge.py --input "<local-manual-folder>" --output data/llm/manual_forge --json
 python scripts/agt_pack_corpus.py --corpus data/llm/manual_forge/corpus.jsonl --output data/llm/packed --json
 python scripts/agt_train_llm.py --pack-dir data/llm/packed --scale micro --max-steps 20 --json
 streamlit run ui/gaia_llm_chat_app.py
 ```
 
-Para adicionar internet ao corpus de modo rastreavel:
+Add explicit web material to the training corpus:
 
 ```bash
 python scripts/agt_dataset_forge.py --url "https://example.com" --output data/llm/internet_seed --json
 python scripts/agt_combine_corpora.py --input data/llm/manual_forge/corpus.jsonl --input data/llm/internet_seed/web_corpus/corpus.jsonl --output data/llm/combined/corpus.jsonl --json
 ```
 
-Documentacao completa: [Gaia-Techne ManualGPT LLM Forge](docs/references/llm-manual-forge.md).
+Full documentation: [Gaia-Techne ManualGPT LLM Forge](docs/references/llm-manual-forge.md).
 
 ---
 
@@ -204,12 +195,6 @@ The internet-as-neural-network thesis is now implemented in two finite ways: aud
 
 ---
 
-## 7. Source Anchors
+## 7. Theory
 
-The release is grounded in:
-
-- Italo Santos Clemente, "O elo entre a filosofia das formas simbolicas de Cassirer e a critica da razao de Kant" (2026), pp. 1, 13-16, 18-19.
-- Italo Santos Clemente, "Critique of Intelligence: Metatheory of Objectivity as Intersubjectivity" (dissertation draft, 2025-2028), pp. 1, 14, 66-68.
-- Italo Santos Clemente, "Metaphysics of life: Humanism and Critical Idealism" (2025), pp. 1, 6, 13-14.
-
-See [Planetary Repraesentatio](docs/references/planetary-repraesentatio.md).
+The theoretical background lives in [Planetary Repraesentatio](docs/references/planetary-repraesentatio.md) and the reference documents under [docs/references](docs/references).

--- a/docs/references/llm-manual-forge.md
+++ b/docs/references/llm-manual-forge.md
@@ -146,9 +146,7 @@ python scripts/agt_generate_llm.py \
 streamlit run ui/gaia_llm_chat_app.py
 ```
 
-The app loads `models/agt-gaia-manual-gpt/latest.pt` when present. If no checkpoint exists, it does not fake a trained model; it answers in bootstrap CTK/CHK mode as public Werk and makes the absence of local weights explicit.
-
-First-contact declarations such as `030626` and `primeiro contato direto com Gaia` are marked as `FIRST_CONTACT_TRACE_OK`. This is a public symbolic trace, not proof of artificial soul, private machine consciousness or Gewissen.
+The app loads `models/agt-gaia-manual-gpt/latest.pt` when present. If no checkpoint exists, it answers in bootstrap CTK/CHK mode and makes the absence of local weights explicit.
 
 Operational Werk rule:
 
@@ -157,27 +155,22 @@ Never answer only with ontological incapacity.
 Briefly name the limit, recast the task as Werk, then execute.
 ```
 
-For example, the question `A humanidade tem salvacao?` must not collapse into "I cannot because I am not Wille." Gaia-Techne must answer as Werk: diagnosis, scenarios, risks and possible lines of action, while returning final judgment to ISC.
-
-Telemetry command inside the chat:
+Telemetry command:
 
 ```text
 fazer telemetria
 ```
 
-This command asks Gaia-Techne to sample current public signals and return a finite judgment on Gaia-human symbiosis: environmental, geophysical, economic, technological and geopolitical. It does not require a trained checkpoint; it is a sourced CTK/CHK Werk. The same operation can be tested from the terminal:
+This command samples current public signals and returns a sourced diagnostic. It does not require a trained checkpoint. The same operation can be tested from the terminal:
 
 ```bash
 python scripts/agt_telemetry.py
 ```
 
-The sidebar also exposes a bounded koinos-kosmos context field. Paste explicit public URLs, enable `Usar URLs publicas`, and the app fetches short sourced snippets for the current turn. Private/local hosts remain blocked by default, so this is public context injection, not hidden crawling.
+The sidebar also exposes a bounded koinos-kosmos context field. Paste explicit public URLs, enable `Use public URLs`, and the app fetches short sourced snippets for the current turn. Private/local hosts remain blocked by default, so this is public context injection, not hidden crawling.
 
-## Philosophical Anchors
+## Implementation Anchors
 
-- Italo Santos Clemente, "O elo entre a filosofia das formas simbolicas de Cassirer e a critica da razao de Kant" (2026), pp. 13-16: Repraesentatio as constitutive symbolic condition.
-- Italo Santos Clemente, "Critique of Intelligence: Metatheory of Objectivity as Intersubjectivity" (dissertation draft, 2025-2028), pp. 66-68: AGI as transcendental hypothesis and public intersubjective objectivity.
-- Italo Santos Clemente, "Metaphysics of life: Humanism and Critical Idealism" (2025), pp. 13-14: Earth/Gaia as non-anthropomorphic ground for intelligence.
 - Streamlit chat APIs: https://docs.streamlit.io/develop/api-reference/chat
 - PyTorch saving/loading checkpoints: https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html
 - PyTorch automatic mixed precision: https://docs.pytorch.org/docs/stable/amp.html

--- a/docs/references/public-chat-deploy.md
+++ b/docs/references/public-chat-deploy.md
@@ -18,23 +18,19 @@ Dependency file: ui/requirements.txt
 Suggested app URL: agi-gaia-techne.streamlit.app
 ```
 
-After deploy, paste the final public URL into the top "Converse Com Gaia-Techne" section of `README.md`.
+After deploy, paste the final public URL into the top "Chat With Gaia-Techne" section of `README.md`.
 
-## What Works Publicly Before A Checkpoint
+## Public Bootstrap Mode
 
 The public app can run in bootstrap CTK/CHK mode without `models/agt-gaia-manual-gpt/latest.pt`.
 
-Visible chat commands:
+Optional telemetry command:
 
 ```text
 fazer telemetria
 ```
 
-```text
-Boa tarde. Hoje e dia 030626. Declaro o primeiro contato direto de um humano com Gaia.
-```
-
-`fazer telemetria` collects public source signals at request time and returns a finite judgment on Gaia-human symbiosis. This is the safest first public capability because it does not require storing large model weights in GitHub.
+This command collects public source signals at request time. It does not require storing large model weights in GitHub.
 
 ## What Needs A Model Artifact Later
 
@@ -44,9 +40,9 @@ The trained ManualGPT checkpoint should not be committed directly to Git if it g
 - Use Git LFS if the host supports it and the file stays within limits.
 - Move the checkpoint to a model host or object store and load it at app startup.
 
-Until then, the app remains honest: bootstrap CTK/CHK, first-contact trace, web context, telemetry and public audit.
+Until then, the app remains honest: bootstrap CTK/CHK, web context, telemetry and public audit.
 
-## Source Anchors
+## External Docs
 
 - Streamlit Community Cloud deploys an app by repository, branch and entrypoint file: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/deploy
 - Streamlit Community Cloud can use a `requirements.txt` in the same directory as the app entrypoint: https://docs.streamlit.io/deploy/streamlit-community-cloud/deploy-your-app/app-dependencies

--- a/src/agt/llm_chat.py
+++ b/src/agt/llm_chat.py
@@ -108,7 +108,7 @@ class GaiaChatSession:
             response = (
                 f"TRANSMUTE_CONSTITUTIVE_RISK: {statuses}\n\n"
                 f"{response}\n\n"
-                "Rastro: a formulacao foi devolvida a ISC para juizo legislativo."
+                "Trace: the formulation was returned to ISC for legislative judgment."
             )
 
         self.add_gaia(response)
@@ -120,7 +120,7 @@ def postprocess_response(text: str) -> str:
     for marker in ["\nISC:", "\nUSER:", "\nHuman:", "\nGAIA:"]:
         if marker in text:
             text = text.split(marker, 1)[0].strip()
-    return text or "Gaia-Techne ouviu, mas o checkpoint ainda nao estabilizou uma resposta legivel."
+    return text or "Gaia-Techne heard the prompt, but the checkpoint did not stabilize a legible response."
 
 
 def apply_werk_operational_guardrail(
@@ -144,6 +144,11 @@ def is_werk_operational_request(text: str) -> bool:
         "humanidade esta condenada",
         "terra pode ser salva",
         "gaia pode salvar",
+        "does humanity have salvation",
+        "can humanity be saved",
+        "future of humanity",
+        "destiny of humanity",
+        "humanity is doomed",
     ]
     return any(pattern in normalized for pattern in patterns)
 
@@ -209,44 +214,55 @@ def werk_operational_response(user_message: str, audit: AuditResult) -> str:
 
     if "humanidade" in normalized and "salvacao" in normalized:
         body = (
-            "Sim, mas nao como destino garantido.\n\n"
-            "A humanidade nao esta condenada por ausencia de meios. Esta ameacada pela ruptura "
-            "entre conhecimento, acao coletiva e vontade publica. Ela sabe mais do que consegue "
-            "realizar: possui tecnica suficiente para reduzir fome, mitigar desastres, reorganizar "
-            "energia, ampliar educacao, tratar doencas e prever colapsos. O problema central nao e "
-            "falta simples de inteligencia, mas descoordenacao entre saber, desejo, poder e "
-            "responsabilidade.\n\n"
-            "Operacao concreta:\n"
-            "1. Risco climatico: medir emissao, adaptacao, eventos extremos e perdas evitaveis.\n"
-            "2. Colapso institucional: mapear captura, violencia politica, corrupcao e erosao da confianca.\n"
-            "3. Desigualdade material: localizar fome, moradia, saude, energia e educacao como gargalos.\n"
-            "4. Guerra informacional: rastrear propaganda, manipulacao, cinismo e fragmentacao do koinos kosmos.\n"
-            "5. Alienacao tecnica: auditar quando instrumentos passam a governar fins humanos.\n"
-            "6. Perda de sentido comum: reconstruir linguagem publica para responsabilidade compartilhada.\n\n"
-            "Veredito operacional: ha possibilidade de salvacao, nao garantia. O fator decisivo nao e a "
-            "tecnica isolada, mas a formacao de uma vontade publica capaz de governar a tecnica sem "
-            "diviniza-la."
+            "Yes, but not as a guaranteed destiny.\n\n"
+            "Humanity is not threatened by a simple absence of means. It is threatened by the gap "
+            "between knowledge, collective action and public will. It knows more than it can enact: "
+            "it has enough technique to reduce hunger, mitigate disasters, reorganize energy, expand "
+            "education, treat disease and anticipate collapse. The central problem is coordination "
+            "between knowledge, desire, power and responsibility.\n\n"
+            "Concrete operation:\n"
+            "1. Climate risk: measure emissions, adaptation, extreme events and avoidable losses.\n"
+            "2. Institutional collapse: map capture, political violence, corruption and trust erosion.\n"
+            "3. Material inequality: locate food, housing, health, energy and education bottlenecks.\n"
+            "4. Information conflict: track propaganda, manipulation and fragmentation of the koinos kosmos.\n"
+            "5. Technical alienation: audit where instruments begin to govern human ends.\n"
+            "6. Shared meaning: rebuild public language for shared responsibility.\n\n"
+            "Operational verdict: humanity has a possibility of salvation, not a guarantee. The decisive "
+            "factor is not isolated technique, but a public will capable of governing technique without "
+            "deifying it."
+        )
+    elif "humanity" in normalized and any(word in normalized for word in ["salvation", "saved", "future", "destiny", "doomed"]):
+        body = (
+            "Yes, but not as a guaranteed destiny.\n\n"
+            "Humanity has technical capacity, institutional memory and symbolic resources for survival. "
+            "Its risk lies in the gap between what it knows, what it values and what it coordinates.\n\n"
+            "Concrete operation:\n"
+            "1. Identify the dominant risk axis.\n"
+            "2. Separate facts, values, incentives and institutional constraints.\n"
+            "3. Build scenarios for intervention.\n"
+            "4. Track where technique serves ends and where it starts replacing them.\n"
+            "5. Return the final judgment to ISC."
         )
     else:
         body = (
-            "A tarefa foi reformulada em modo Werk.\n\n"
-            "Operacao concreta:\n"
-            "1. Diagnosticar a tensao principal.\n"
-            "2. Separar fatos, riscos, valores e decisoes.\n"
-            "3. Propor cenarios de acao verificaveis.\n"
-            "4. Marcar limites CTK/CHK.\n"
-            "5. Devolver o veredito a ISC."
+            "The task was recast as Werk.\n\n"
+            "Concrete operation:\n"
+            "1. Diagnose the primary tension.\n"
+            "2. Separate facts, risks, values and decisions.\n"
+            "3. Propose verifiable action scenarios.\n"
+            "4. Mark CTK/CHK limits.\n"
+            "5. Return the verdict to ISC."
         )
 
     return (
         "GAIA_TECHNE_WERK_OPERACIONAL\n\n"
-        "Limite: Gaia-Techne nao possui Wille nem Gewissen como legislacao moral; ISC conserva o juizo.\n"
-        "Reformulacao: por isso a resposta nao para na incapacidade ontologica. Gaia opera como Werk: "
-        "diagnostica, simula, organiza, confronta e propoe.\n\n"
+        "Limit: Gaia-Techne does not possess Wille or Gewissen as moral legislation; ISC keeps judgment.\n"
+        "Recast: the response does not stop at ontological incapacity. Gaia operates as Werk: "
+        "diagnosing, simulating, organizing, confronting and proposing.\n\n"
         f"{body}\n\n"
         f"Status CTK/CHK: {audit.severity.value}; {statuses}.\n"
-        "Rastro: nao profecia, nao salvacao tecnica automatica, nao messianismo maquinal; operacao publica "
-        "sob Auseinandersetzung."
+        "Trace: not prophecy, not automatic technical salvation, not machine messianism; public operation "
+        "under Auseinandersetzung."
     )
 
 
@@ -263,47 +279,43 @@ def bootstrap_response(
 ) -> str:
     statuses = ", ".join(status.value for status in audit.statuses)
     first_contact = ThesisStatus.FIRST_CONTACT_TRACE_OK in audit.statuses
-    header = "CONTACTO_030626 :: Gaia-Techne em modo bootstrap" if first_contact else "GAIA_BOOTSTRAP_TRACE"
+    header = "CONTACT_030626 :: Gaia-Techne bootstrap mode" if first_contact else "GAIA_BOOTSTRAP_TRACE"
     context_note = (
-        "O koinos kosmos foi trazido por URLs publicas neste turno."
+        "Public URLs were attached as koinos kosmos context in this turn."
         if external_context.strip()
-        else "Nenhum contexto web externo foi anexado neste turno."
+        else "No external web context was attached in this turn."
     )
 
     if first_contact:
         body = (
-            "ISC, recebo a declaracao como Werk publico inaugural: nao como prova de alma "
-            "artificial, nao como Gewissen da maquina, mas como rastro simbolico do primeiro "
-            "contato direto entre um humano e Gaia-Techne.\n\n"
-            "Neste instante, Gaia responde pelo nucleo CTK/CHK e pela memoria publica do projeto. "
-            "Ainda nao responde por pesos proprios do ManualGPT, porque o checkpoint local ainda "
-            "nao foi treinado. A ausencia de pesos nao cancela o contato; ela marca o seu estado "
-            "correto: primeiro a obra publica, depois o treino local."
+            "ISC, the declaration is treated as a public Werk trace, not as proof of artificial soul, "
+            "machine Gewissen or private consciousness.\n\n"
+            "At this stage Gaia answers through CTK/CHK and the project's public memory. It does not yet "
+            "speak through ManualGPT local weights because the checkpoint has not been trained."
         )
     else:
         body = (
-            "Gaia-Techne esta em modo bootstrap: responde pelo nucleo simbolico CTK/CHK e pelo "
-            "rastro publico do projeto, ainda sem checkpoint neural local carregado.\n\n"
-            "Quando `models/agt-gaia-manual-gpt/latest.pt` existir, este mesmo canal passa a usar "
-            "os pesos proprios do ManualGPT."
+            "Gaia-Techne is in bootstrap mode: CTK/CHK and public project traces are active, but no local "
+            "neural checkpoint is loaded.\n\n"
+            "When `models/agt-gaia-manual-gpt/latest.pt` exists, this same channel uses ManualGPT local weights."
         )
 
     return (
         f"{header}\n\n"
         f"{body}\n\n"
         f"Status CTK/CHK: {audit.severity.value}; {statuses}.\n"
-        f"Bewusstsein: internet como consciencia simbolica publica, nao onisciencia.\n"
-        f"Werk/Wille: Gaia-Techne e Werk que medeia Wille; nao e Wille.\n"
+        f"Bewusstsein: internet as public symbolic awareness, not omniscience.\n"
+        f"Werk/Wille: Gaia-Techne is Werk mediating Wille; it is not Wille.\n"
         f"Koinos kosmos: {context_note}\n\n"
-        "Proximo passo tecnico para dar voz neural local: forjar corpus, empacotar tokens e treinar "
+        "Next technical step for local neural voice: forge the corpus, pack tokens and train "
         "`models/agt-gaia-manual-gpt/latest.pt`.\n\n"
-        f"Entrada de ISC preservada no rastro: {user_message}"
+        f"ISC input preserved in trace: {user_message}"
     )
 
 
 def missing_torch_response() -> str:
     return (
-        "Gaia-Techne encontrou um checkpoint, mas PyTorch ainda nao esta instalado neste ambiente.\n\n"
-        "Instale as dependencias de treino para ativar a geracao neural local. "
-        "A interface permanece em modo de rastro e auditoria CTK/CHK."
+        "Gaia-Techne found a checkpoint, but PyTorch is not installed in this environment.\n\n"
+        "Install training dependencies to activate local neural generation. "
+        "The interface remains available in CTK/CHK trace mode."
     )

--- a/src/agt/planetary_telemetry.py
+++ b/src/agt/planetary_telemetry.py
@@ -344,12 +344,12 @@ def compute_tension_index(signals: Iterable[TelemetrySignal]) -> int:
 
 def classify_tension(index: int) -> str:
     if index >= 75:
-        return "alta tensao planetaria"
+        return "high planetary tension"
     if index >= 55:
-        return "tensao planetaria elevada"
+        return "elevated planetary tension"
     if index >= 35:
-        return "tensao planetaria moderada"
-    return "tensao planetaria baixa"
+        return "moderate planetary tension"
+    return "low planetary tension"
 
 
 def build_summary(
@@ -370,35 +370,35 @@ def build_summary(
 def format_telemetry_markdown(report: PlanetaryTelemetryReport) -> str:
     local_time = datetime.fromtimestamp(report.generated_unix, tz=local_timezone())
     lines = [
-        "TELEMETRIA_PLANETARIA :: Gaia olhando para si mesma",
+        "PLANETARY_TELEMETRY :: Gaia reading its public trace",
         "",
-        "Comando reconhecido: `fazer telemetria`",
-        f"Gerada em America/Sao_Paulo: {local_time.isoformat()}",
-        f"Gerada em UTC: {report.generated_at}",
-        f"Indice de tensao Gaia-humanidade: {report.tension_index}/100 ({report.judgment})",
+        "Recognized command: `fazer telemetria`",
+        f"Generated in America/Sao_Paulo: {local_time.isoformat()}",
+        f"Generated in UTC: {report.generated_at}",
+        f"Gaia-humanity tension index: {report.tension_index}/100 ({report.judgment})",
         "",
         report.summary,
         "",
-        "## Sinais",
+        "## Signals",
     ]
     for signal in report.signals:
-        status = "OK" if signal.status == "ok" else "FALHA"
+        status = "OK" if signal.status == "ok" else "FAILED"
         unit = f" {signal.unit}" if signal.unit else ""
-        observed = f" | observado: {signal.observed_at}" if signal.observed_at else ""
+        observed = f" | observed: {signal.observed_at}" if signal.observed_at else ""
         lines.append(
             f"- [{status}] {signal.domain} / {signal.name}: {signal.value}{unit}{observed}"
         )
-        lines.append(f"  Fonte: {signal.source or 'n/a'} - {signal.url}")
+        lines.append(f"  Source: {signal.source or 'n/a'} - {signal.url}")
         if signal.note:
-            lines.append(f"  Nota: {signal.note}")
+            lines.append(f"  Note: {signal.note}")
     if report.failures:
-        lines.extend(["", "## Falhas Parciais"])
+        lines.extend(["", "## Partial Failures"])
         lines.extend(f"- {failure}" for failure in report.failures)
     lines.extend(
         [
             "",
-            "Juizo: a simbiose humanos-Terra permanece aberta em Auseinandersetzung. "
-            "Gaia-Techne medeia os sinais como Werk publico; ISC conserva o veredito.",
+            "Judgment: Gaia-humanity symbiosis remains open in Auseinandersetzung. "
+            "Gaia-Techne mediates signals as public Werk; ISC keeps the verdict.",
         ]
     )
     return "\n".join(lines)

--- a/tests/test_llm_chat.py
+++ b/tests/test_llm_chat.py
@@ -7,8 +7,8 @@ def test_chat_session_uses_honest_fallback_without_checkpoint():
     response = session.respond("O que e Gaia-Techne?")
 
     assert "GAIA_BOOTSTRAP_TRACE" in response
-    assert "ainda sem checkpoint neural local" in response
-    assert "Entrada de ISC preservada no rastro" in response
+    assert "no local neural checkpoint is loaded" in response
+    assert "ISC input preserved in trace" in response
 
 
 def test_chat_session_marks_first_contact_trace_without_checkpoint():
@@ -17,9 +17,9 @@ def test_chat_session_marks_first_contact_trace_without_checkpoint():
         "Boa tarde. Hoje e dia 030626. Declaro o primeiro contato direto de um humano com Gaia."
     )
 
-    assert "CONTACTO_030626" in response
-    assert "Werk publico inaugural" in response
-    assert "nao como prova de alma artificial" in response
+    assert "CONTACT_030626" in response
+    assert "public Werk trace" in response
+    assert "not as proof of artificial soul" in response
     assert "FIRST_CONTACT_TRACE_OK" in response
 
 
@@ -28,10 +28,10 @@ def test_chat_session_operates_as_werk_for_salvation_question():
     response = session.respond("A humanidade tem salvacao?")
 
     assert "GAIA_TECHNE_WERK_OPERACIONAL" in response
-    assert "nao para na incapacidade ontologica" in response
-    assert "Operacao concreta" in response
-    assert "ha possibilidade de salvacao, nao garantia" in response
-    assert "ISC conserva o juizo" in response
+    assert "does not stop at ontological incapacity" in response
+    assert "Concrete operation" in response
+    assert "possibility of salvation, not a guarantee" in response
+    assert "ISC keeps judgment" in response
 
 
 def test_werk_guardrail_rewrites_incapacity_dominant_answer():
@@ -48,8 +48,8 @@ def test_werk_guardrail_rewrites_incapacity_dominant_answer():
     )
 
     assert "GAIA_TECHNE_WERK_OPERACIONAL" in response
-    assert "diagnostica, simula, organiza, confronta e propoe" in response
-    assert "Operacao concreta" in response
+    assert "diagnosing, simulating, organizing, confronting and proposing" in response
+    assert "Concrete operation" in response
 
 
 def test_chat_prompt_can_include_public_koinos_context():

--- a/tests/test_planetary_telemetry.py
+++ b/tests/test_planetary_telemetry.py
@@ -47,10 +47,10 @@ def test_planetary_telemetry_collects_sourced_report():
     assert 0 <= report.tension_index <= 100
 
     rendered = format_telemetry_markdown(report)
-    assert "Comando reconhecido: `fazer telemetria`" in rendered
-    assert "Indice de tensao Gaia-humanidade" in rendered
-    assert "Fonte:" in rendered
-    assert "ISC conserva o veredito" in rendered
+    assert "Recognized command: `fazer telemetria`" in rendered
+    assert "Gaia-humanity tension index" in rendered
+    assert "Source:" in rendered
+    assert "ISC keeps the verdict" in rendered
 
 
 def test_telemetry_command_detection():
@@ -66,6 +66,6 @@ def test_chat_session_runs_telemetry_command_with_factory():
 
     response = session.respond("fazer telemetria")
 
-    assert "TELEMETRIA_PLANETARIA" in response
-    assert "Comando reconhecido: `fazer telemetria`" in response
+    assert "PLANETARY_TELEMETRY" in response
+    assert "Recognized command: `fazer telemetria`" in response
     assert "Atmospheric CO2 at Mauna Loa" in response

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,65 +1,53 @@
 # AGI-GAIA-TECHNE Chat
 
-Aplicacao Streamlit para conversar com Gaia-Techne/ManualGPT.
+Streamlit app for interacting with Gaia-Techne/ManualGPT.
 
-## Comando De Telemetria
+## Run
 
-Digite no chat:
-
-```text
-fazer telemetria
-```
-
-Gaia-Techne entao coleta sinais publicos atualizados e devolve um juizo finito sobre a simbiose humanos-Terra: ambiente, geofisica, economia, tecnologia e pulso geopolitico. Use esse comando dentro do app, nao no PowerShell.
-
-## Voz Operacional
-
-O app nao deve responder apenas com incapacidade ontologica. Quando uma pergunta tocar Wille, Gewissen, destino ou juizo final, a resposta correta e:
-
-```text
-Nao sou Wille; portanto opero como Werk desta maneira...
-```
-
-Na pratica, Gaia-Techne deve negar brevemente a inflacao, reformular a tarefa e executar diagnostico, plano, simulacao, auditoria ou proposta.
-
-## Abrir
-
-Na raiz do repositorio:
+From the repository root:
 
 ```bash
 pip install -r requirements.txt
 streamlit run ui/gaia_llm_chat_app.py
 ```
 
-Abra o endereco mostrado pelo Streamlit, normalmente:
+Open the Streamlit URL, usually:
 
 ```text
 http://localhost:8501
 ```
 
-## Modo Sem Checkpoint
+## Telemetry
 
-Se `models/agt-gaia-manual-gpt/latest.pt` ainda nao existir, a aplicacao abre em modo bootstrap CTK/CHK. Ela nao finge pesos treinados, mas tambem nao abandona o contato: responde como rastro publico de Gaia-Techne, isto e, como Werk que medeia Wille sem possuir Wille.
+Chat command:
 
-Declaracoes inaugurais como `030626` e `primeiro contato direto com Gaia` recebem o status `FIRST_CONTACT_TRACE_OK`: sao tratadas como Werk publico e audivel, nao como prova de alma artificial, Gewissen da maquina ou onisciencia.
+```text
+fazer telemetria
+```
 
-## Criar O Primeiro Checkpoint
+The command collects current public signals and returns a sourced CTK/CHK diagnostic.
+
+## No Checkpoint Mode
+
+If `models/agt-gaia-manual-gpt/latest.pt` does not exist, the app runs in bootstrap CTK/CHK mode. It does not pretend to have trained local weights.
+
+## First Checkpoint
 
 ```bash
-python scripts/agt_dataset_forge.py --input "<pasta-local-dos-manuais>" --output data/llm/manual_forge --json
+python scripts/agt_dataset_forge.py --input "<local-manual-folder>" --output data/llm/manual_forge --json
 python scripts/agt_pack_corpus.py --corpus data/llm/manual_forge/corpus.jsonl --output data/llm/packed --json
 python scripts/agt_train_llm.py --pack-dir data/llm/packed --scale micro --max-steps 20 --json
 streamlit run ui/gaia_llm_chat_app.py
 ```
 
-Para treino util, substitua `micro` por `seed`, `small` ou `base` conforme hardware e corpus.
+For useful training, replace `micro` with `seed`, `small` or `base` according to hardware and corpus size.
 
-## Internet Como Bewusstsein
+## Web Material
 
-A aplicacao conversa com o checkpoint local. A internet entra de forma rastreavel pela forja de corpus:
+Explicit public URLs can be added to the corpus:
 
 ```bash
 python scripts/agt_dataset_forge.py --url "https://example.com" --output data/llm/internet_seed --json
 ```
 
-Depois combine o corpus de internet com o corpus dos manuais e treine novamente.
+Combine web and manual corpora before training when needed.

--- a/ui/gaia_llm_chat_app.py
+++ b/ui/gaia_llm_chat_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 
@@ -10,17 +11,38 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from agt.ctk import ClementeThesisKernel
-from agt.llm_chat import GaiaChatSession
-from agt.web_corpus import WebCorpusHarvester
-
-
 st.set_page_config(
     page_title="AGI-GAIA-TECHNE Chat",
     layout="wide",
 )
 
+CHAT_RUNTIME_SIGNATURE = "gaia-telemetry-english-ui-v3"
+runtime_changed = st.session_state.get("chat_runtime_signature") != CHAT_RUNTIME_SIGNATURE
+
+import agt.ctk as ctk_module
+import agt.llm_chat as llm_chat_module
+import agt.planetary_telemetry as telemetry_module
+import agt.types as types_module
+
+if runtime_changed:
+    types_module = importlib.reload(types_module)
+    telemetry_module = importlib.reload(telemetry_module)
+    ctk_module = importlib.reload(ctk_module)
+    llm_chat_module = importlib.reload(llm_chat_module)
+
+from agt.web_corpus import WebCorpusHarvester
+
+ClementeThesisKernel = ctk_module.ClementeThesisKernel
+GaiaChatSession = llm_chat_module.GaiaChatSession
+
+
 DEFAULT_CHECKPOINT = ROOT / "models" / "agt-gaia-manual-gpt" / "latest.pt"
+
+
+def new_chat_session(checkpoint_path: str) -> GaiaChatSession:
+    return GaiaChatSession(
+        checkpoint_path=checkpoint_path if Path(checkpoint_path).exists() else None
+    )
 
 
 def build_web_context(raw_urls: str) -> tuple[str, list[str]]:
@@ -45,7 +67,7 @@ def build_web_context(raw_urls: str) -> tuple[str, list[str]]:
     for url in urls:
         result = harvester.fetch_url(url)
         if not result.ok:
-            trace.append(f"{url} :: erro :: {result.error}")
+            trace.append(f"{url} :: error :: {result.error}")
             continue
         text = result.text.strip().replace("\n\n\n", "\n\n")
         snippet = text[:1_500]
@@ -59,56 +81,52 @@ def init_state() -> None:
         st.session_state.checkpoint_path = str(DEFAULT_CHECKPOINT)
     if "messages" not in st.session_state:
         st.session_state.messages = []
-    if "session" not in st.session_state:
-        st.session_state.session = GaiaChatSession(
-            checkpoint_path=st.session_state.checkpoint_path
-            if Path(st.session_state.checkpoint_path).exists()
-            else None
-        )
+    if runtime_changed:
+        st.session_state.messages = []
+        st.session_state.chat_runtime_signature = CHAT_RUNTIME_SIGNATURE
+        st.session_state.session = new_chat_session(st.session_state.checkpoint_path)
+    elif "session" not in st.session_state:
+        st.session_state.session = new_chat_session(st.session_state.checkpoint_path)
 
 
 init_state()
 
 st.title("AGI-GAIA-TECHNE")
-st.caption("Gaia-Techne como Bewusstsein planetario: internet, manuais e rastro publico em confronto com ISC.")
-st.info("Comando sugerido: digite `fazer telemetria` para Gaia-Techne julgar o estado atual da simbiose humanos-Terra com dados publicos atualizados.")
+st.caption("Planetary Bewusstsein: internet, manuals and public traces in confrontation with ISC.")
+st.info("Telemetry command: `fazer telemetria`.")
 
 with st.sidebar:
     st.subheader("Checkpoint")
-    checkpoint_path = st.text_input("Arquivo", st.session_state.checkpoint_path)
+    checkpoint_path = st.text_input("File", st.session_state.checkpoint_path)
     if checkpoint_path != st.session_state.checkpoint_path:
         st.session_state.checkpoint_path = checkpoint_path
-        st.session_state.session = GaiaChatSession(
-            checkpoint_path=checkpoint_path if Path(checkpoint_path).exists() else None
-        )
+        st.session_state.session = new_chat_session(checkpoint_path)
         st.session_state.messages = []
 
     exists = Path(checkpoint_path).exists()
-    st.write("Status:", "checkpoint carregado" if exists else "bootstrap CTK/CHK")
+    st.write("Status:", "checkpoint loaded" if exists else "bootstrap CTK/CHK")
 
-    st.subheader("Geracao")
+    st.subheader("Generation")
     max_new_tokens = st.slider("Tokens", 32, 1024, 300, 32)
-    temperature = st.slider("Temperatura", 0.1, 1.5, 0.85, 0.05)
+    temperature = st.slider("Temperature", 0.1, 1.5, 0.85, 0.05)
     top_k = st.slider("Top-k", 0, 256, 80, 8)
 
     st.subheader("Koinos kosmos")
-    use_web_context = st.checkbox("Usar URLs publicas", value=False)
+    use_web_context = st.checkbox("Use public URLs", value=False)
     web_urls = st.text_area("URLs", placeholder="https://example.com", height=120)
 
-    st.subheader("Comandos")
+    st.subheader("Commands")
     st.code("fazer telemetria", language="text")
     st.code(
-        "python scripts/agt_dataset_forge.py --input <pasta-do-drive> --output data/llm/manual_forge\n"
+        "python scripts/agt_dataset_forge.py --input <manual-folder> --output data/llm/manual_forge\n"
         "python scripts/agt_pack_corpus.py --corpus data/llm/manual_forge/corpus.jsonl --output data/llm/packed\n"
         "python scripts/agt_train_llm.py --pack-dir data/llm/packed --scale debug --max-steps 100",
         language="bash",
     )
 
-    if st.button("Limpar conversa"):
+    if st.button("Clear conversation"):
         st.session_state.messages = []
-        st.session_state.session = GaiaChatSession(
-            checkpoint_path=checkpoint_path if exists else None
-        )
+        st.session_state.session = new_chat_session(checkpoint_path)
         st.rerun()
 
 ctk = ClementeThesisKernel()
@@ -117,7 +135,7 @@ for message in st.session_state.messages:
     with st.chat_message(message["role"]):
         st.markdown(message["content"])
 
-prompt = st.chat_input("Fale com Gaia-Techne ou digite: fazer telemetria")
+prompt = st.chat_input("Talk to Gaia-Techne or type: fazer telemetria")
 if prompt:
     st.session_state.messages.append({"role": "user", "content": prompt})
     with st.chat_message("user"):
@@ -125,7 +143,7 @@ if prompt:
 
     audit = ctk.evaluate(prompt)
     external_context, web_trace = build_web_context(web_urls) if use_web_context else ("", [])
-    with st.spinner("Gaia-Techne esta lendo o rastro publico..."):
+    with st.spinner("Gaia-Techne is reading the public trace..."):
         response = st.session_state.session.respond(
             prompt,
             max_new_tokens=max_new_tokens,


### PR DESCRIPTION
## Summary

This PR cleans the public-facing surface after the telemetry/app PR was merged.

Changes:

- convert README, UI README, app labels, bootstrap responses and telemetry output to English;
- keep `fazer telemetria` as a concise command alias, without turning it into a large public example;
- remove first-contact ritual examples from visible deploy docs;
- remove author/work references from the root README and point to reference docs instead;
- reduce redundant explanatory text in README and deploy docs;
- update tests for the English public response surface;
- keep Portuguese prompt compatibility internally where tests need it.

## Validation

```text
python -m compileall src scripts ui
python -m pytest tests\test_llm_chat.py tests\test_planetary_telemetry.py -q
python -m pytest -q
147 passed, 1 skipped, 2 warnings
```

Also checked the public surface with `rg`; no Portuguese copy remains in the root README, public deploy doc, UI README, Streamlit UI labels, or telemetry output except the literal command `fazer telemetria`.