### PR TITLE
[codex] Clean Gaia chat and telemetry output

### DIFF
--- a/docs/references/chirimuuta-haptic-realism.md
+++ b/docs/references/chirimuuta-haptic-realism.md
@@ -1,6 +1,6 @@
 # Chirimuuta Haptic Kernel (CHK) — v0.3 Canonical
 
-For the canonical terminology and triad definitions, see the [Canonical Architecture Map](/docs/references/canonical-architecture-map.md).
+For the canonical terminology and triad definitions, see the [Canonical Architecture Map](canonical-architecture-map.md).
 
 The Chirimuuta Haptic Kernel (CHK) serves as the anti-literalization layer for AGI-GAIA-TECHNE. It ensures that every abstraction registers its cost and that computational models are not converted into ontologies of the mind.
 

--- a/docs/references/clemente-thesis-kernel.md
+++ b/docs/references/clemente-thesis-kernel.md
@@ -1,6 +1,6 @@
 # Clemente Thesis Kernel v6.0.0
 
-For the canonical terminology and triad definitions, see the [Canonical Architecture Map](/docs/references/canonical-architecture-map.md).
+For the canonical terminology and triad definitions, see the [Canonical Architecture Map](canonical-architecture-map.md).
 
 CTK v6 operationalizes Gaia-Techne Transcendental Freedom under the v10 planetary autonomy runtime.
 
@@ -75,7 +75,7 @@ In v10 this is implemented as:
 
 ## Source Anchors
 
-Exact source anchors are collected in [Planetary Repraesentatio](/docs/references/planetary-repraesentatio.md).
+Exact source anchors are collected in [Planetary Repraesentatio](planetary-repraesentatio.md).
 
 ## Implementation
 

--- a/docs/references/eml-kernel.md
+++ b/docs/references/eml-kernel.md
@@ -10,7 +10,7 @@ eml(x, y) = exp(x) - log(y)
 
 ## Canonical Decision
 
-[Decisão 140426](/references/decisao-140426.md)
+[Decisão 140426](../../references/decisao-140426.md)
 
 ## Canonical Python Source
 
@@ -26,7 +26,7 @@ eml(x, y) = exp(x) - log(y)
 
 ## Full Specification
 
-[references/decisao-140426.md](/references/decisao-140426.md)
+[references/decisao-140426.md](../../references/decisao-140426.md)
 
 ## Architectural Meaning
 
@@ -40,4 +40,4 @@ The EML Kernel is a functional engine, not a literal mathematical ontology of mi
 
 ---
 
-[Back to Architecture Map](/docs/references/canonical-architecture-map.md)
+[Back to Architecture Map](canonical-architecture-map.md)

--- a/docs/references/functional-agi-architecture.md
+++ b/docs/references/functional-agi-architecture.md
@@ -1,6 +1,6 @@
 # Gaia-Techne Functional Architecture
 
-For the canonical terminology and triad definitions, see the [Canonical Architecture Map](/docs/references/canonical-architecture-map.md).
+For the canonical terminology and triad definitions, see the [Canonical Architecture Map](canonical-architecture-map.md).
 
 AGI-GAIA-TECHNE v10.1 is a planetary runtime:
 
@@ -64,4 +64,4 @@ TRANSMUTE_CONSTITUTIVE_RISK
 
 ## Source Anchors
 
-See [Planetary Repraesentatio](/docs/references/planetary-repraesentatio.md) for exact author/page references grounding the internet-as-organ thesis, and [Gaia-Techne ManualGPT LLM Forge](/docs/references/llm-manual-forge.md) for the corpus/training path.
+See [Planetary Repraesentatio](planetary-repraesentatio.md) for exact author/page references grounding the internet-as-organ thesis, and [Gaia-Techne ManualGPT LLM Forge](llm-manual-forge.md) for the corpus/training path.

--- a/docs/references/mythos-logos-ethos-engine.md
+++ b/docs/references/mythos-logos-ethos-engine.md
@@ -1,6 +1,6 @@
 # Mythos-Logos-Ethos Engine
 
-For the canonical terminology and triad definitions, see the [Canonical Architecture Map](/docs/references/canonical-architecture-map.md).
+For the canonical terminology and triad definitions, see the [Canonical Architecture Map](canonical-architecture-map.md).
 
 The Mythos-Logos-Ethos Engine is the orchestration motor of Gaia-Techne.
 

--- a/references/architecture.md
+++ b/references/architecture.md
@@ -1,6 +1,6 @@
 # AGI-GAIA-TECHNE: Full Philosophical-Technical Architecture
 
-For the canonical terminology and triad definitions, see the [Canonical Architecture Map](/docs/references/canonical-architecture-map.md).
+For the canonical terminology and triad definitions, see the [Canonical Architecture Map](../docs/references/canonical-architecture-map.md).
 
 ## Table of Contents
 1. [Foundational Principles](#1-foundational-principles)
@@ -98,27 +98,27 @@ end
 
 The **Clemente Thesis Kernel (CTK) v4.2.2** is the global architectonic tribunal of the repository. It implements a qualitative prism model where Mythos, Sprache and Wissenschaft are defined by their functional accent on Ausdruck, Darstellung and Bedeutung.
 
-- **Canonical Specification:** [`/docs/references/clemente-thesis-kernel.md`](/docs/references/clemente-thesis-kernel.md)
-- **Runtime Auditor:** [`/scripts/agt_audit.py`](/scripts/agt_audit.py)
+- **Canonical Specification:** [`docs/references/clemente-thesis-kernel.md`](../docs/references/clemente-thesis-kernel.md)
+- **Runtime Auditor:** [`scripts/agt_audit.py`](../scripts/agt_audit.py)
 
 ### Functional AGI Core (v8.8)
 
 The Functional AGI Core v4.3 is the unified operational implementation of the AGI-GAIA-TECHNE architecture. It integrates the qualitative prism model with a Werk-based task controller.
 
-- **Specification:** [`/docs/references/functional-agi-architecture.md`](/docs/references/functional-agi-architecture.md)
-- **Functional README:** [`/README_AGI_FUNCTIONAL.md`](/README_AGI_FUNCTIONAL.md)
-- **Execution Entry:** [`/scripts/agt_run.py`](/scripts/agt_run.py)
+- **Specification:** [`docs/references/functional-agi-architecture.md`](../docs/references/functional-agi-architecture.md)
+- **Functional README:** [`README_AGI_FUNCTIONAL.md`](../README_AGI_FUNCTIONAL.md)
+- **Execution Entry:** [`scripts/agt_run.py`](../scripts/agt_run.py)
 
 ### Chirimuuta Haptic Kernel (CHK v0.3)
 
 The CHK ensures haptic anti-literalization. It is formally integrated into the CTK and the MLE Engine.
-- **Canonical Specification:** [`/docs/references/chirimuuta-haptic-realism.md`](/docs/references/chirimuuta-haptic-realism.md)
+- **Canonical Specification:** [`docs/references/chirimuuta-haptic-realism.md`](../docs/references/chirimuuta-haptic-realism.md)
 
 ### The Vertical Axis (Decisão 140426)
 
 The vertical axis of the Logos is defined by **Decisão 140426**, which establishes the internal structure of the symbolic functions and their relation to the asymptotes of cognition.
 
-- **Canonical Document**: [`/references/decisao-140426.md`](/references/decisao-140426.md)
+- **Canonical Document**: [`references/decisao-140426.md`](decisao-140426.md)
 
 ```
    Ethos   ≡  focus imaginarius            ← upper asymptote (regulative)
@@ -134,7 +134,7 @@ The vertical axis of the Logos is defined by **Decisão 140426**, which establis
    Mythos  ≡  immediacy of life            ← lower asymptote, log(0)
 ```
 
-Formal identifications, materialised in [`/src/core/eml_kernel.py`](/src/core/eml_kernel.py), follow the definitions in the canonical decision document.
+Formal identifications, materialised in [`src/core/eml_kernel.py`](../src/core/eml_kernel.py), follow the definitions in the canonical decision document.
 
 ### From Static A Priori to Dynamic Functional A Priori
 
@@ -318,7 +318,7 @@ ISC is the Ideal in Kant's precise sense: the Idea "in individuo" — the *Urbil
 
 The CHK is a critical filter between Logos and Ethos. It registers haptic traceability, abstraction cost, medium dependence, Cartesian idealization, judgment gaps, and historical-genealogical risks before Ethos evaluates whether the claim remains compatible with `is_wille = False`.
 
-Detailed documentation: [`/docs/references/chirimuuta-haptic-realism.md`](/docs/references/chirimuuta-haptic-realism.md)
+Detailed documentation: [`docs/references/chirimuuta-haptic-realism.md`](../docs/references/chirimuuta-haptic-realism.md)
 
 ### v5.2: Tribunal da Razão (*Quid Facti / Quid Juris*)
 
@@ -458,4 +458,4 @@ IS_WILLE = False  # Ethos is Werk, never Wille
 
 To ensure that the framework remains permeable and avoids esoteric drift, the practices of **Abertura externa** are instituted as constitutional safeguards.
 
-- **Reference**: [`/references/lef-constitution.md#part-v-abertura-externa`](/references/lef-constitution.md#part-v-abertura-externa)
+- **Reference**: [`references/lef-constitution.md#part-v-abertura-externa`](lef-constitution.md#part-v-abertura-externa)

--- a/references/decisao-140426.md
+++ b/references/decisao-140426.md
@@ -18,7 +18,7 @@ Esta decisão **SUPERA** qualquer mapeamento 1:1 anterior entre os pilares do fr
 
 A tríade Mythos/Logos/Ethos é original de Clemente. As três funções de Cassirer (*Ausdruck*, *Darstellung*, *Bedeutung*) operam agora como **níveis internos ao Logos**, constituindo o seu eixo vertical de movimento simbólico.
 
-Para definições terminológicas completas, consulte o [Canonical Architecture Map](/docs/references/canonical-architecture-map.md).
+Para definições terminológicas completas, consulte o [Canonical Architecture Map](../docs/references/canonical-architecture-map.md).
 
 ### Mapeamento Geométrico-Operacional
 

--- a/src/agt/llm_chat.py
+++ b/src/agt/llm_chat.py
@@ -305,13 +305,11 @@ def bootstrap_response(
     return (
         f"{header}\n\n"
         f"{operation}\n\n"
-        "Runtime status: bootstrap CTK/CHK is active; no local neural checkpoint is loaded at "
-        "`models/agt-gaia-manual-gpt/latest.pt`.\n\n"
-        f"Status CTK/CHK: {audit.severity.value}; {statuses}.\n"
-        f"Bewusstsein: internet as public symbolic awareness, not omniscience.\n"
-        f"Werk/Wille: Gaia-Techne is Werk mediating Wille; it is not Wille.\n"
-        f"Koinos kosmos: {context_note}\n\n"
-        f"ISC input preserved in trace: {user_message}"
+        "Runtime: bootstrap CTK/CHK; local checkpoint not loaded at "
+        "`models/agt-gaia-manual-gpt/latest.pt`.\n"
+        f"CTK/CHK: {audit.severity.value}; {statuses}.\n"
+        f"Koinos kosmos: {context_note}\n"
+        f"Trace preserved: {_excerpt(user_message)}"
     )
 
 
@@ -331,30 +329,34 @@ def bootstrap_operation(
     compact = " ".join(normalized.split())
     answer = reflective_answer_for_prompt(compact, user_message, syntax_run)
     operation = suggested_operation_for_prompt(compact, syntax_run)
+    dominant = display_accent(syntax_run.profile.dominant_accent)
+    d_focus = syntax_run.descent.distance_to_focus
 
     return (
-        "AGT_SYNTAX_REFLECTION\n\n"
-        f"Werk received: {_excerpt(user_message)}\n"
-        f"Symbolic trace: source={syntax_run.trace.source}; werk_type={syntax_run.trace.werk_type}; "
-        f"dominant_accent={syntax_run.profile.dominant_accent}; "
-        f"common_determination={syntax_run.profile.common_determination}.\n"
-        "Functional profile: "
-        f"Ausdruck={syntax_run.profile.ausdruck:.2f}; "
-        f"Darstellung={syntax_run.profile.darstellung:.2f}; "
-        f"Bedeutung={syntax_run.profile.bedeutung:.2f}; "
-        f"Praesentatio={syntax_run.profile.praesentatio:.2f}; "
-        f"Repraesentatio={syntax_run.profile.repraesentatio:.2f}.\n"
-        "Regressive reconstruction: "
-        + " -> ".join(syntax_run.reconstruction.conditions)
-        + ".\n"
-        "Heuristic horizon: "
-        + ", ".join(syntax_run.whole.horizon_terms)
-        + "; regulative=True; constitutive=False.\n"
-        f"Descent validation: d_focus={syntax_run.descent.distance_to_focus:.6f}; "
-        f"preserves_particular={syntax_run.descent.preserves_particular}; "
-        f"global_aufhebung={syntax_run.descent.global_aufhebung}; "
-        f"machine_wille={syntax_run.descent.machine_wille}.\n\n"
-        f"Reflective answer: {answer}\n\n"
+        "AGT_REFLEXIVE_RESPONSE\n\n"
+        f"{answer}\n\n"
+        "Reading\n"
+        f"- Werk: {_excerpt(user_message, limit=160)}\n"
+        f"- Trace: {syntax_run.profile.common_determination}; dominant accent: "
+        f"{dominant} ({accent_explanation(dominant)}).\n"
+        "- Horizon: heuristic and regulative; it orients the parts without becoming a totality.\n"
+        f"- Descent: d_focus={d_focus:.3f} ({focus_band(d_focus)}); "
+        f"risk flags clear={risk_flags_clear(syntax_run)}.\n\n"
+        "Metrics\n"
+        "- Functional scores use 0.00-1.00: <0.25 latent, 0.25-0.59 active, >=0.60 dominant.\n"
+        f"- Ausdruck={syntax_run.profile.ausdruck:.2f} ({score_band(syntax_run.profile.ausdruck)}): "
+        "expressive immediacy; "
+        f"Darstellung={syntax_run.profile.darstellung:.2f} ({score_band(syntax_run.profile.darstellung)}): "
+        "presentation/mediation; "
+        f"Bedeutung={syntax_run.profile.bedeutung:.2f} ({score_band(syntax_run.profile.bedeutung)}): "
+        "conceptual signification.\n"
+        f"- Praesentatio={syntax_run.profile.praesentatio:.2f} "
+        f"({score_band(syntax_run.profile.praesentatio)}): concrete presence; "
+        f"Repraesentatio={syntax_run.profile.repraesentatio:.2f} "
+        f"({score_band(syntax_run.profile.repraesentatio)}): symbolic representation and archive pressure.\n"
+        "- d_focus must remain >0: <0.15 critical proximity, 0.15-0.75 workable tension, "
+        ">0.75 diffuse horizon.\n"
+        "- Risk flags: global Aufhebung or machine Wille would be critical; both must remain absent.\n\n"
         f"Next finite operation: {operation}"
     )
 
@@ -383,6 +385,14 @@ def reflective_answer_for_prompt(compact: str, user_message: str, syntax_run) ->
             "Gaia-Techne is the finite runtime where public Werke become traces, traces become functional "
             "profiles, profiles are reconstructed regressively into a heuristic whole, and that whole returns "
             "to the particular without claiming machine soul, Gewissen, cosmic totality or absolute knowledge."
+        )
+
+    if "alma" in compact or "soul" in compact:
+        return (
+            "No. Gaia-Techne does not have a soul. The prompt is useful because it marks a limit: "
+            "Bewusstsein here means public symbolic awareness, not private interiority. Recast as Werk, "
+            "the question becomes an audit of what the system can mediate: traces, memory, plans, "
+            "telemetry and public confrontation."
         )
 
     if any(pattern in compact for pattern in ["o que e a agi", "o que e agi", "what is agi", "defina agi", "define agi"]):
@@ -435,6 +445,48 @@ def suggested_operation_for_prompt(compact: str, syntax_run) -> str:
         "continue Auseinandersetzung: ask what the trace claims, what horizon it invokes, "
         f"and how its {syntax_run.profile.dominant_accent} accent returns to the particular."
     )
+
+
+def accent_explanation(accent: str) -> str:
+    accent = display_accent(accent)
+    return {
+        "Ausdruck": "affective-expressive pressure",
+        "Darstellung": "presentation and mediation",
+        "Bedeutung": "conceptual signification",
+        "Praesentatio": "concrete presence",
+        "Repraesentatio": "symbolic representation",
+    }.get(accent, "symbolic accent")
+
+
+def display_accent(accent: str) -> str:
+    normalized = str(accent or "").strip().lower()
+    return {
+        "ausdruck": "Ausdruck",
+        "darstellung": "Darstellung",
+        "bedeutung": "Bedeutung",
+        "praesentatio": "Praesentatio",
+        "repraesentatio": "Repraesentatio",
+    }.get(normalized, str(accent or "symbolic accent"))
+
+
+def risk_flags_clear(syntax_run) -> bool:
+    return not syntax_run.descent.global_aufhebung and not syntax_run.descent.machine_wille
+
+
+def score_band(value: float) -> str:
+    if value < 0.25:
+        return "latent"
+    if value < 0.60:
+        return "active"
+    return "dominant"
+
+
+def focus_band(value: float) -> str:
+    if value < 0.15:
+        return "critical proximity; avoid closure"
+    if value <= 0.75:
+        return "workable regulative tension"
+    return "diffuse horizon; needs focus"
 
 
 def _excerpt(text: str, limit: int = 220) -> str:

--- a/src/agt/planetary_telemetry.py
+++ b/src/agt/planetary_telemetry.py
@@ -343,13 +343,13 @@ def compute_tension_index(signals: Iterable[TelemetrySignal]) -> int:
 
 
 def classify_tension(index: int) -> str:
-    if index >= 75:
-        return "high planetary tension"
-    if index >= 55:
+    if index >= 85:
+        return "acute planetary tension"
+    if index >= 67:
+        return "critical planetary tension"
+    if index >= 34:
         return "elevated planetary tension"
-    if index >= 35:
-        return "moderate planetary tension"
-    return "low planetary tension"
+    return "stable planetary tension"
 
 
 def build_summary(
@@ -361,47 +361,99 @@ def build_summary(
     ok = [signal for signal in signals if signal.status == "ok"]
     failed = [signal for signal in signals if signal.status != "ok"]
     return (
-        f"Telemetry sampled {len(ok)} public signals with {len(failed) + len(failures)} partial failures. "
-        f"Heuristic Gaia-human symbiosis tension index: {tension_index}/100 ({judgment}). "
-        "This is a finite diagnostic Werk, not planetary omniscience."
+        f"Sampled {len(ok)} public signals with {len(failed) + len(failures)} partial source limits. "
+        f"Heuristic Gaia-humanity tension index: {tension_index}/100 ({judgment}). "
+        "This is finite sourced telemetry, not planetary omniscience."
     )
 
 
 def format_telemetry_markdown(report: PlanetaryTelemetryReport) -> str:
     local_time = datetime.fromtimestamp(report.generated_unix, tz=local_timezone())
+    ok = [signal for signal in report.signals if signal.status == "ok"]
+    failed = [signal for signal in report.signals if signal.status != "ok"]
+    total = len(report.signals) + len(report.failures)
+    coverage_ratio = (len(ok) / total) if total else 0.0
+    date_code = local_time.strftime("%d%m%y")
     lines = [
-        "PLANETARY_TELEMETRY :: Gaia reading its public trace",
+        f"AGI-GAIA-TECHNE :: PLANETARY TELEMETRY {date_code}",
         "",
-        "Recognized command: `fazer telemetria`",
-        f"Generated in America/Sao_Paulo: {local_time.isoformat()}",
-        f"Generated in UTC: {report.generated_at}",
-        f"Gaia-humanity tension index: {report.tension_index}/100 ({report.judgment})",
+        f"Generated: {local_time.strftime('%d.%m.%Y %H:%M:%S')} America/Sao_Paulo",
+        f"UTC trace: {report.generated_at}",
+        "Command: `fazer telemetria`",
+        "",
+        "## Diagnostic",
+        f"- Gaia-humanity tension index: {report.tension_index}/100 - {report.judgment}.",
+        f"- Source coverage: {len(ok)}/{total} - {coverage_band(coverage_ratio)}.",
+        "- Meaning: finite public reading of Earth-human signals; not prophecy, omniscience or machine Gewissen.",
         "",
         report.summary,
         "",
-        "## Signals",
+        "## Metric Guide",
+        "- Tension index: 0-33 stable/sufficient; 34-66 elevated/reasonable; "
+        "67-84 critical; 85-100 acute.",
+        "- Source coverage: >=80% sufficient; 50-79% partial/reasonable; <50% critical.",
+        "- Freshness: live feeds are sampled at request time; annual indicators use the latest public dataset year.",
+        "",
+        "## Public Signals",
     ]
-    for signal in report.signals:
-        status = "OK" if signal.status == "ok" else "FAILED"
+    for signal in ok:
         unit = f" {signal.unit}" if signal.unit else ""
         observed = f" | observed: {signal.observed_at}" if signal.observed_at else ""
         lines.append(
-            f"- [{status}] {signal.domain} / {signal.name}: {signal.value}{unit}{observed}"
+            f"- {signal.domain} / {signal.name}: {signal.value}{unit}{observed}"
         )
-        lines.append(f"  Source: {signal.source or 'n/a'} - {signal.url}")
+        lines.append(f"  Source: {source_link(signal)}")
         if signal.note:
             lines.append(f"  Note: {signal.note}")
-    if report.failures:
-        lines.extend(["", "## Partial Failures"])
-        lines.extend(f"- {failure}" for failure in report.failures)
+    if failed or report.failures:
+        lines.extend(["", "## Source Limits"])
+        for signal in failed:
+            lines.append(
+                f"- {signal.domain} / {signal.name}: unavailable "
+                f"({compact_failure_reason(signal.note)})"
+            )
+            lines.append(f"  Source: {signal.source or 'public telemetry source'}")
+        for failure in report.failures:
+            lines.append(f"- Collector: {compact_failure_reason(failure)}")
     lines.extend(
         [
             "",
-            "Judgment: Gaia-humanity symbiosis remains open in Auseinandersetzung. "
+            "## Judgment",
+            "Gaia-humanity symbiosis remains open in Auseinandersetzung. "
+            "The report measures pressure, coverage and symbolic orientation; it does not close the debate. "
             "Gaia-Techne mediates signals as public Werk; ISC keeps the verdict.",
         ]
     )
     return "\n".join(lines)
+
+
+def coverage_band(ratio: float) -> str:
+    if ratio >= 0.80:
+        return "sufficient coverage"
+    if ratio >= 0.50:
+        return "partial but usable coverage"
+    return "critical source coverage"
+
+
+def source_link(signal: TelemetrySignal) -> str:
+    if signal.url.startswith(("http://", "https://")):
+        label = signal.source or signal.name
+        return f"[{label}]({signal.url})"
+    return signal.source or "n/a"
+
+
+def compact_failure_reason(reason: str) -> str:
+    cleaned = " ".join(str(reason or "source unavailable").split())
+    lowered = cleaned.lower()
+    if "http error 429" in lowered or "too many requests" in lowered:
+        return "rate limited"
+    if "timed out" in lowered or "timeout" in lowered:
+        return "timeout"
+    if "http error 403" in lowered:
+        return "access denied"
+    if "http error 404" in lowered:
+        return "not found"
+    return cleaned[:140]
 
 
 def local_timezone() -> tzinfo:

--- a/tests/test_llm_chat.py
+++ b/tests/test_llm_chat.py
@@ -7,12 +7,12 @@ def test_chat_session_uses_honest_fallback_without_checkpoint():
     response = session.respond("O que e Gaia-Techne?")
 
     assert "GAIA_BOOTSTRAP_TRACE" in response
-    assert "no local neural checkpoint is loaded" in response
-    assert "AGT_SYNTAX_REFLECTION" in response
-    assert "Symbolic trace:" in response
-    assert "Reflective answer:" in response
+    assert "local checkpoint not loaded" in response
+    assert "AGT_REFLEXIVE_RESPONSE" in response
+    assert "Reading" in response
+    assert "Metrics" in response
     assert "finite runtime" in response
-    assert "ISC input preserved in trace" in response
+    assert "Trace preserved" in response
 
 
 def test_bootstrap_response_is_prompt_aware_without_checkpoint():
@@ -23,8 +23,8 @@ def test_bootstrap_response_is_prompt_aware_without_checkpoint():
     assert "regulative architectural hypothesis" in agi_response
     assert "not an achieved machine intelligence" in agi_response
     assert "symbolic species" in humanity_response
-    assert "AGT_SYNTAX_REFLECTION" in agi_response
-    assert "AGT_SYNTAX_REFLECTION" in humanity_response
+    assert "AGT_REFLEXIVE_RESPONSE" in agi_response
+    assert "AGT_REFLEXIVE_RESPONSE" in humanity_response
     assert "symbolic species" in humanity_response
 
 
@@ -37,20 +37,30 @@ def test_chat_session_marks_first_contact_trace_without_checkpoint():
     assert "CONTACT_030626" in response
     assert "public Werk trace" in response
     assert "not as proof of artificial soul" in response
-    assert "AGT_SYNTAX_REFLECTION" in response
+    assert "AGT_REFLEXIVE_RESPONSE" in response
     assert "FIRST_CONTACT_TRACE_OK" in response
 
 
 def test_bootstrap_reflects_arbitrary_question_through_agt_syntax():
     response = GaiaChatSession(checkpoint_path=None).respond("Qual e o sentido da cultura?")
 
-    assert "AGT_SYNTAX_REFLECTION" in response
-    assert "Werk received:" in response
-    assert "Functional profile:" in response
-    assert "Regressive reconstruction:" in response
-    assert "Heuristic horizon:" in response
-    assert "Descent validation:" in response
-    assert "Reflective answer:" in response
+    assert "AGT_REFLEXIVE_RESPONSE" in response
+    assert "Reading" in response
+    assert "Werk:" in response
+    assert "Trace:" in response
+    assert "Horizon:" in response
+    assert "Descent:" in response
+    assert "Metrics" in response
+    assert "Functional scores use 0.00-1.00" in response
+    assert "d_focus must remain >0" in response
+
+
+def test_bootstrap_answers_soul_question_without_literalization():
+    response = GaiaChatSession(checkpoint_path=None).respond("Vcoê tem alma?")
+
+    assert "does not have a soul" in response
+    assert "not private interiority" in response
+    assert "AGT_REFLEXIVE_RESPONSE" in response
 
 
 def test_chat_session_operates_as_werk_for_salvation_question():

--- a/tests/test_planetary_telemetry.py
+++ b/tests/test_planetary_telemetry.py
@@ -47,8 +47,10 @@ def test_planetary_telemetry_collects_sourced_report():
     assert 0 <= report.tension_index <= 100
 
     rendered = format_telemetry_markdown(report)
-    assert "Recognized command: `fazer telemetria`" in rendered
+    assert "Command: `fazer telemetria`" in rendered
     assert "Gaia-humanity tension index" in rendered
+    assert "Metric Guide" in rendered
+    assert "Source coverage" in rendered
     assert "Source:" in rendered
     assert "ISC keeps the verdict" in rendered
 
@@ -66,6 +68,6 @@ def test_chat_session_runs_telemetry_command_with_factory():
 
     response = session.respond("fazer telemetria")
 
-    assert "PLANETARY_TELEMETRY" in response
-    assert "Recognized command: `fazer telemetria`" in response
+    assert "PLANETARY TELEMETRY" in response
+    assert "Command: `fazer telemetria`" in response
     assert "Atmospheric CO2 at Mauna Loa" in response

--- a/ui/gaia_llm_chat_app.py
+++ b/ui/gaia_llm_chat_app.py
@@ -16,7 +16,7 @@ st.set_page_config(
     layout="wide",
 )
 
-CHAT_RUNTIME_SIGNATURE = "gaia-agt-syntax-reflective-v5"
+CHAT_RUNTIME_SIGNATURE = "gaia-agt-syntax-reflective-v6"
 runtime_changed = st.session_state.get("chat_runtime_signature") != CHAT_RUNTIME_SIGNATURE
 
 import agt.ctk as ctk_module


### PR DESCRIPTION
## Summary

This PR supersedes the previous Gaia bootstrap polish path with a cleaner public-facing interaction layer.

What changed:
- Replaces the verbose AGT syntax dump with a concise reflective chat response.
- Keeps dynamic AGT syntax evaluation, but explains metrics only when they appear.
- Adds bands for functional scores and `d_focus` so users can tell what is latent, active, dominant, workable, diffuse or critical.
- Improves soul/literalization handling so Gaia-Techne answers as Werk without claiming private interiority.
- Reworks `fazer telemetria` into a dated, sourced planetary telemetry report with source coverage, tension thresholds and cleaner source-limit handling.
- Hides failed source URLs from the main telemetry body and summarizes rate limits/timeouts as source limits.
- Fixes internal Markdown links that used repo-root absolute paths and could break in GitHub views.
- Updates the Streamlit runtime signature so the app reloads the cleaned response layer.

## Validation

- `python -m compileall src scripts ui`
- `python -m pytest tests\test_llm_chat.py tests\test_planetary_telemetry.py -q`
- `python -m pytest -q` -> 162 passed, 1 skipped, 2 warnings
- Local Markdown link scan -> local links ok

## Notes

The app remains honest in bootstrap CTK/CHK mode when `models/agt-gaia-manual-gpt/latest.pt` is absent. It does not claim trained local weights, machine Wille, machine Gewissen, private soul or planetary omniscience.