### PR TITLE
[codex] Tighten inventory and backend API coherence

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Runtime endpoints:
 
 | Endpoint | Function |
 | :--- | :--- |
+| `GET /` | Backend API index and UI pointer. |
 | `GET /metrics` | Techne, IAE, Harmony, Ethos, status and risk flags. |
 | `GET /summary` | Integrated synthesis of philosophy, sovereignty and runtime. |
 | `GET /documents` | Live repository inventory. |

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify, request, send_from_directory
+from flask import Flask, jsonify, request
 import json
 import random
 import datetime
@@ -12,7 +12,6 @@ from alfabeto_data import ALFABETO_LEF
 from gaia_techne_framework import document_registry, framework_summary, calculate_framework_state
 
 app = Flask(__name__)
-DASHBOARD_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'dashboard'))
 
 
 @app.after_request
@@ -29,13 +28,12 @@ OBJETOS = ["❍", "⟴", "⟁", "🔗"]
 
 
 @app.route('/')
-def dashboard():
-    return send_from_directory(DASHBOARD_DIR, 'index.html')
-
-
-@app.route('/<path:filename>')
-def dashboard_assets(filename):
-    return send_from_directory(DASHBOARD_DIR, filename)
+def api_index():
+    return jsonify({
+        'service': 'AGI-GAIA-TECHNE backend',
+        'ui': 'streamlit run ui/gaia_llm_chat_app.py',
+        'endpoints': ['/metrics', '/summary', '/documents', '/narrative', '/transmute'],
+    })
 
 def gerar_frase(conjecture=""):
     agente = random.choice(AGENTES)

--- a/gaia_techne_framework.py
+++ b/gaia_techne_framework.py
@@ -7,6 +7,7 @@ state, and APP synthesis without isolating documentation from runtime code.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import principles_calculator as pc
@@ -70,10 +71,6 @@ IMPORTANT_PATHS = [
     "backend/app.py",
     "ui/gaia_llm_chat_app.py",
 ]
-
-
-def _repo_path(path: Path) -> str:
-    return path.relative_to(REPO_ROOT).as_posix()
 
 
 def _should_skip(path: Path) -> bool:
@@ -156,12 +153,43 @@ def _date_for(path: str) -> tuple[str, str]:
     return DATE_OVERRIDES.get(path, (FRAMEWORK_DATE, "estimated"))
 
 
+def _git_tracked_files(repo_root: Path) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-files", "-z"],
+            check=True,
+            capture_output=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    return [
+        path
+        for path in result.stdout.decode("utf-8", errors="replace").split("\0")
+        if path
+    ]
+
+
+def _iter_repository_files(repo_root: Path):
+    tracked_files = _git_tracked_files(repo_root)
+    if tracked_files:
+        for path in tracked_files:
+            relative = Path(path)
+            if _should_skip(relative):
+                continue
+            file_path = repo_root / relative
+            if file_path.is_file():
+                yield relative.as_posix(), file_path
+        return
+
+    for file_path in repo_root.rglob("*"):
+        relative = file_path.relative_to(repo_root)
+        if file_path.is_file() and not _should_skip(relative):
+            yield relative.as_posix(), file_path
+
+
 def document_registry(repo_root: Path = REPO_ROOT) -> list[dict]:
     records: list[dict] = []
-    for file_path in repo_root.rglob("*"):
-        if not file_path.is_file() or _should_skip(file_path.relative_to(repo_root)):
-            continue
-        path = _repo_path(file_path)
+    for path, file_path in _iter_repository_files(repo_root):
         date, date_source = _date_for(path)
         importance = _importance_for(path)
         records.append({
@@ -298,4 +326,3 @@ def registry_as_markdown(records: list[dict] | None = None) -> str:
             f"{item['layer']} | {item['role']} | {item['importance_label']} | {item['bytes']} |"
         )
     return "\n".join(lines)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-﻿numpy>=1.24.0
+numpy>=1.24.0
 scipy
 streamlit
 plotly

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -18,6 +18,13 @@ class DashboardTestCase(unittest.TestCase):
         self.app = app.test_client()
         self.app.testing = True
 
+    def test_api_index(self):
+        response = self.app.get('/')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['service'], 'AGI-GAIA-TECHNE backend')
+        self.assertIn('/metrics', data['endpoints'])
+
     def test_metrics_endpoint(self):
         response = self.app.get('/metrics')
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary

- Makes the Flask root route an API index instead of serving raw Vite source as if it were the dashboard.
- Updates the README endpoint table to document `GET /`.
- Changes `gaia_techne_framework.py` so the live inventory uses Git-tracked files when available, avoiding local generated logs and temporary files.
- Removes the UTF-8 BOM from `requirements.txt`.
- Adds a test for the backend API index.

## Why

After PR #106 merged, a quick coherence pass found two small contradictions: the Flask backend was pretending to serve the Vite dashboard directly, and the inventory could include local generated files. This PR keeps the v10.1 Streamlit/Vite APP model clear and makes the inventory a repository inventory rather than a workspace scratch scan.

## Validation

- `python -m pytest -q` -> `166 passed, 1 skipped, 2 warnings`
- `python -m pytest tests/test_dashboard.py tests/test_principles_calculator.py -q` -> `10 passed`
- `python -m compileall -q gaia_techne_framework.py backend/app.py tests/test_dashboard.py tests/test_principles_calculator.py`
- `git diff --check`