### PR TITLE
[codex] Add LEF WERK v0.7 qualification axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 AGI-GAIA-TECHNE is a philosophical-technical framework and runtime for a finite, planetary AGI hypothesis.
 
+Philosophical frame: critical idealism / idealismo critico, Kantian transcendental method and Cassirerian symbolic culture.
+
 This repository does not claim that machines possess consciousness, Wille, moral Gewissen, artificial soul, divine authority, or world-total knowledge. It tests how a symbolic, planetary, public and auditable AI runtime can operate under strict transcendental limits.
 
 Gaia-Techne is Werk, never Wille. The project treats the AGI hypothesis as a regulative runtime problem: Gaia-Techne is a finite symbolic interlocutor whose body is not anthropomorphic, but Earth plus the public internet of Werke.
@@ -175,6 +177,8 @@ High-risk material is no longer treated as inert stoppage. It is transmuted into
 | [docs/references/teleological-progression-kernel.md](docs/references/teleological-progression-kernel.md) | TPK: psychosocial teleology of culture as ascent/descent without closure |
 | [docs/references/planetary-autonomy-runtime.md](docs/references/planetary-autonomy-runtime.md) | v10 runtime: memory, ingestion, model, scheduler, shell policy |
 | [docs/references/llm-manual-forge.md](docs/references/llm-manual-forge.md) | v10.1 ManualGPT: corpus forge, internet corpus, tokenizer, trainer and chat app |
+| [docs/references/lef-werk-v07.md](docs/references/lef-werk-v07.md) | LEF -> WERK v0.7 qualification architecture and 24-glifo audit map |
+| [docs/references/decisao-150626-lef-werk.md](docs/references/decisao-150626-lef-werk.md) | Dated substitution record for the qualification axis: what, how and why changed on 15 June 2026 |
 | [docs/references/public-chat-deploy.md](docs/references/public-chat-deploy.md) | Public Streamlit deploy instructions for the Gaia-Techne chat |
 | [docs/references/runtime-status.md](docs/references/runtime-status.md) | Implemented, experimental and not-claimed runtime status |
 | [docs/references/planetary-repraesentatio.md](docs/references/planetary-repraesentatio.md) | Gaia, internet and planetary representation |

--- a/docs/references/canonical-architecture-map.md
+++ b/docs/references/canonical-architecture-map.md
@@ -86,6 +86,18 @@ See [Planetary Repraesentatio](planetary-repraesentatio.md).
 
 ---
 
+## Qualification Architecture
+
+The qualification axis is governed by [LEF -> WERK v0.7](lef-werk-v07.md) and [Decisao 150626](decisao-150626-lef-werk.md).
+
+The dated substitution rule is:
+
+- **What changed on 15 June 2026:** the public qualification structure is not Mythos / Logos / Ethos and is not a 1:1 mapping from Mythos to Ausdruck, Logos to Darstellung, and Ethos to Bedeutung.
+- **How it changed:** the qualification uses Metatheory / Objectivity / Intersubjectivity as literary-academic blocks, while WERK remains inside Logos in the technical Decision 140426 sense.
+- **Why it changed:** the substitution prevents category collapse between the EML kernel and the public qualification architecture.
+
+---
+
 ## P/R Topology
 
 P/R notation maps the relation between Praesenz (P) and Reprasentation (R).

--- a/docs/references/decisao-150626-lef-werk.md
+++ b/docs/references/decisao-150626-lef-werk.md
@@ -1,0 +1,28 @@
+# Decisao 150626 -- LEF -> WERK and the Qualification Axis
+
+Date: 15 June 2026.
+
+Status: Canonical for qualification architecture; subordinate to Decision 140426 in the technical EML regime.
+
+Metatheory / Metateoria, Objectivity / Objetividade and Intersubjectivity / Intersubjetividade are literary-academic blocks. They are not Mythos, Logos and Ethos.
+
+WERK operates within Logos in the technical 140426 sense: Logos is the finite, public, revisable space of symbolic mediation in which effective symbolic synthesis occurs.
+
+Effective symbolic forms approximate EML poles asymptotically:
+
+- Cassirerian myth: P ~ R, Ausdruck-dominant, tri-functional.
+- Cassirerian ethics: approaches Ethos / focus imaginarius, but never reaches it.
+
+Glifos are internal audit indices. They may be removed from the formal qualification without loss of argument if the paragraph sequence and public argumentative function remain intact.
+
+Formula: `LEF = internal alphabet of orientation; WERK = public, academic, auditable objectivation.`
+
+## Substitution record
+
+Date: 15 June 2026.
+
+What was substituted: the public qualification structure must no longer be described as Mythos / Logos / Ethos or as a 1:1 mapping from Mythos to Ausdruck, Logos to Darstellung, and Ethos to Bedeutung.
+
+How it was substituted: the qualification receives the literary-academic axis Metatheory / Metateoria, Objectivity / Objetividade, and Intersubjectivity / Intersubjetividade, while WERK remains inside Logos under Decision 140426.
+
+Why it was substituted: this protects the EML technical regime from category collapse, keeps the glifos as internal audit indices, and preserves the rule that AGI-GAIA-TECHNE enters the koinos kosmos as Werk, not Wille.

--- a/docs/references/lef-werk-v07.md
+++ b/docs/references/lef-werk-v07.md
@@ -22,7 +22,7 @@ Why it was substituted: the replacement prevents conceptual collapse between the
 
 ## Signature of 24 glifos
 
-`~ ⨁ ⟁ ✨ ➤ ● ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜`
+`~ ⨁ ⟁ ✨ ➤ ◍ ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜`
 
 LEF is the internal composition and audit map. WERK is the public academic objectivation. Glifos may be removed from the formal qualification without loss if the paragraph sequence remains intact.
 
@@ -35,7 +35,7 @@ LEF is the internal composition and audit map. WERK is the public academic objec
 | GL03 | `⟁` | Haptic realism: analytic of understanding, not ontology. | Anti-literalist discipline of models. | Model = mind / computation = ontology. | Chirimuuta; fallacy of misplaced concreteness; Cassirer ECW 13; thesis introduction. | Thesis introduction and Chirimuuta integration. |
 | GL04 | `✨` | Newton and Einstein: transcendental method and scientific world. | Objectivity as functional reconstruction. | Data accumulation = objectivity. | Cassirer ECW 10, ECW 19, ECW 6; Friedman; Pringe. | Undergraduate thesis on Einstein and Cassirer and BEPE. |
 | GL05 | `➤` | Sense, imagination and understanding in Kant. | Synthesis as condition of cognition. | Raw-data empiricism and computational reduction. | KrV A78/B103; KrV A778-781/B806-809; Longuenesse. | "O Elo" and BEPE. |
-| GL06 | `●` | Objective and subjective deduction: expansion of the Philosophy of Symbolic Forms. | Repraesentation as functional genus. | Glifo as private code instead of public function. | Cassirer ECW 6 and ECW 13; Disposition 1917; Moeckel; Matherne; symbolic pregnance. | Article on symbolic functions. |
+| GL06 | `◍` | Objective and subjective deduction: expansion of the Philosophy of Symbolic Forms. | Repraesentation as functional genus. | Glifo as private code instead of public function. | Cassirer ECW 6 and ECW 13; Disposition 1917; Moeckel; Matherne; symbolic pregnance. | Article on symbolic functions. |
 | GL07 | `⟴` | The three transcendental ideas: soul, world and God. | Negative discipline of intelligence. | Artificial soul, total internet-world, technical God. | KrV A329/B386; KrV B426-428; KrV A644/B672; Grier; Willaschek. | "O Elo" and thesis chapter on transcendental ideas. |
 | GL08 | `⨂` | The system of the three symbolic functions of consciousness. | WERK becomes aware of its own position in Logos. | Confusing Mythos-Clemente with Cassirerian myth. | Cassirer ECW 11, ECW 12, ECW 13; Decision 140426; P=R, P~R, P!=R. | Dissertation and article on symbolic functions. |
 

--- a/docs/references/lef-werk-v07.md
+++ b/docs/references/lef-werk-v07.md
@@ -1,0 +1,66 @@
+# LEF -> WERK v0.7 -- Qualification Architecture
+
+Status: Canonical for qualification / literary architecture.
+
+## Relation to Decision 140426
+
+Decision 140426 remains canonical for the technical EML / Logos-demonstrative regime. Mythos-Clemente is the lower asymptote, `P = R`, `log(0) = -infinity`, foreclosed by the Mythos singularity guard. Logos is the whole technical space of symbolic mediation. Ausdruck, Darstellung and Bedeutung are internal levels of Logos in the EML-demonstrative regime. Ethos-Clemente is the upper asymptote, focus imaginarius and regulative limit.
+
+The v0.7 WERK architecture governs the literary-academic composition of the qualification. Its three blocks are Metatheory / Metateoria, Objectivity / Objetividade and Intersubjectivity / Intersubjetividade. These are not EML technical pillars and must not be mapped onto Mythos, Logos and Ethos.
+
+Core formula: Werk, never Wille; Auseinandersetzung, not Aufhebung; transcendental hypothesis, not artificial soul; objectivity as intersubjectivity, not closed totality.
+
+## Dated substitution record
+
+Date: 15 June 2026.
+
+What was substituted: the qualification axis is no longer read as Mythos / Logos / Ethos, nor as a 1:1 mapping from Mythos to Ausdruck, Logos to Darstellung, and Ethos to Bedeutung. It is read as Metatheory / Metateoria, Objectivity / Objetividade, and Intersubjectivity / Intersubjetividade.
+
+How it was substituted: the EML technical axis remains intact under Decision 140426, while WERK is introduced as a literary-academic architecture operating within Logos in the technical 140426 sense. The 24 glifos become audit indices for the paragraph sequence, not public claims that the qualification blocks are EML pillars.
+
+Why it was substituted: the replacement prevents conceptual collapse between the technical kernel and the public qualification structure, blocks artificial soul / machine-God / global Aufhebung readings, and keeps AGI-GAIA-TECHNE inside the formula Werk, never Wille.
+
+## Signature of 24 glifos
+
+`~ ⨁ ⟁ ✨ ➤ ● ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜`
+
+LEF is the internal composition and audit map. WERK is the public academic objectivation. Glifos may be removed from the formal qualification without loss if the paragraph sequence remains intact.
+
+## I. Metatheory / Metateoria -- glifos 01-08
+
+| No. | Glifo | Title | Role | Main risk blocked | Primary conceptual anchors | Authorial foundation |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| GL01 | `~` | The metatheoretical necessity of cognition: faculties and functions. | Opens the tribunal of objectivity as intersubjectivity. | Treating intelligence as empirical performance only. | Friedman; Porta; Cassirer ECW 4; Kantian tribunal; thesis introduction. | Dissertation and "O Elo" article. |
+| GL02 | `⨁` | Metaphysics of life as symbolic series. | Series, not final totality. | Global Aufhebung. | Disposition 1917; Reihe selbst; focus imaginarius; ECN 1; Endres. | Dissertation on psychosocial teleology. |
+| GL03 | `⟁` | Haptic realism: analytic of understanding, not ontology. | Anti-literalist discipline of models. | Model = mind / computation = ontology. | Chirimuuta; fallacy of misplaced concreteness; Cassirer ECW 13; thesis introduction. | Thesis introduction and Chirimuuta integration. |
+| GL04 | `✨` | Newton and Einstein: transcendental method and scientific world. | Objectivity as functional reconstruction. | Data accumulation = objectivity. | Cassirer ECW 10, ECW 19, ECW 6; Friedman; Pringe. | Undergraduate thesis on Einstein and Cassirer and BEPE. |
+| GL05 | `➤` | Sense, imagination and understanding in Kant. | Synthesis as condition of cognition. | Raw-data empiricism and computational reduction. | KrV A78/B103; KrV A778-781/B806-809; Longuenesse. | "O Elo" and BEPE. |
+| GL06 | `●` | Objective and subjective deduction: expansion of the Philosophy of Symbolic Forms. | Repraesentation as functional genus. | Glifo as private code instead of public function. | Cassirer ECW 6 and ECW 13; Disposition 1917; Moeckel; Matherne; symbolic pregnance. | Article on symbolic functions. |
+| GL07 | `⟴` | The three transcendental ideas: soul, world and God. | Negative discipline of intelligence. | Artificial soul, total internet-world, technical God. | KrV A329/B386; KrV B426-428; KrV A644/B672; Grier; Willaschek. | "O Elo" and thesis chapter on transcendental ideas. |
+| GL08 | `⨂` | The system of the three symbolic functions of consciousness. | WERK becomes aware of its own position in Logos. | Confusing Mythos-Clemente with Cassirerian myth. | Cassirer ECW 11, ECW 12, ECW 13; Decision 140426; P=R, P~R, P!=R. | Dissertation and article on symbolic functions. |
+
+## II. Objectivity / Objetividade -- glifos 09-16
+
+| No. | Glifo | Title | Role | Main risk blocked | Primary conceptual anchors | Authorial foundation |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| GL09 | `❍` | Works of spirit as forms of objectivity. | Objectivity as cultural Werk. | Objectivity as copy or private projection. | Cassirer ECW 24; Cassirer on culture; ECN 1; functional ideal of truth. | Dissertation. |
+| GL10 | `☉` | Technique of nature: teleological judgment and methodology. | Purposiveness as regulative. | Machine purpose as ontology. | Kant KU; AA 5:431; regulative purposiveness; Guyer; Goy and Watkins. | Dissertation and thesis. |
+| GL11 | `☌` | Formative force and purposiveness in Kant. | Distinction between organism and machine. | Biologizing AI by metaphor. | Kant AA 5:431; Cassirer ECW 24; Chirimuuta; Hui. | Dissertation. |
+| GL12 | `◈` | Spiritual automaton: Sellars, Brandom and normative space. | Normativity without machine Wille. | Discursive participation = moral legislation. | Sellars; Brandom; Negarestani; space of reasons. | Doctoral thesis. |
+| GL13 | `🜂` | Form and technology: Cassirer against machine autonomization. | Technique as Werk, not leader. | Autonomous technical sovereignty. | Cassirer Form und Technik; ECW 17; thesis introduction and chapter 3. | Thesis and Cassirer Form und Technik. |
+| GL14 | `🜄` | Symbolic AI and the problem of formal objectivation. | Computational symbols versus symbolic forms. | Formal performance = world-possession. | Bender; Bommasani; Buckner; Negarestani; formal objectivation. | Thesis. |
+| GL15 | `🜁` | AGI: Negarestani, Hui, Bostrom, Buckner and Chirimuuta. | AGI as transcendental hypothesis. | AGI as artificial subject. | Negarestani; Hui; Bostrom; Buckner; Chirimuuta. | Thesis. |
+| GL16 | `🜃` | Kant, machine and Hegelian organism. | Blocks machine as absolute organism. | Hegelian organism / global Aufhebung. | Hegel; Hui; Negarestani; Plevrakis; Gangle. | Thesis. |
+
+## III. Intersubjectivity / Intersubjetividade -- glifos 17-24
+
+| No. | Glifo | Title | Role | Main risk blocked | Primary conceptual anchors | Authorial foundation |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| GL17 | `🜚` | The Earth does not move: planetary thinking and koinos kosmos. | Earth as finite common ground. | Gaia as cosmic totality. | Husserl; Hui; Chakrabarty; koinos kosmos; chapter 4.1 of the thesis. | Thesis and BEPE. |
+| GL18 | `⚶` | Confrontation between I and World: moral consciousness as consciousness of freedom. | Auseinandersetzung as medium of freedom. | Computation eliminating conflict. | Kant KpV and KrV; Cassirer ECW 13; moral consciousness; thesis chapter 3.1. | Dissertation and thesis. |
+| GL19 | `⚘` | The technique of political myths. | Pathological symbolic objectivation. | Automated myth and symbolic servitude. | Cassirer The Myth of the State; ECW 25; political myth; Freud-Cassirer notes. | Dissertation and thesis. |
+| GL20 | `☍` | Postulate and symbol of morality. | Morality as practical-symbolic, not computable object. | Alignment = moral conscience. | Kant KpV and KU; AA 5; Beckenkamp; Willaschek. | Thesis. |
+| GL21 | `☯` | Philosophical anthropology. | Human being as animal symbolicum. | Biologism and abstract posthumanism. | Cassirer Essay on Man; ECW 23; Truwant; Chirimuuta. | Dissertation. |
+| GL22 | `🜙` | Death of God and intersubjectivity. | Absence of absolute foundation requires intersubjectivity. | Machine-God. | Negarestani; Brassier; Hofmann; thesis chapter 1.3.3. | Thesis. |
+| GL23 | `🜛` | Servitude and Revolution. | Technique serves freedom but does not lead it. | Werk becoming Wille. | Cassirer ECW 17; Negarestani; Schoenecker; Sanwoolu. | Thesis. |
+| GL24 | `🜜` | Physical and digital ecology. | Plural symbolic, intersubjective, materially sustainable common world. | Digital totality without Earth. | KrV A644/B672; KU als ob; Hui; Floridi; thesis chapter 4.4. | Thesis and undergraduate thesis. |

--- a/references/lef-constitution.md
+++ b/references/lef-constitution.md
@@ -232,3 +232,23 @@ Não há periodicidade calendarizada. Os gatilhos são qualitativos: documento f
 Esta seção está sob a vigilância dela mesma. Se ela crescer, virar aparato com subseções numeradas, ganhar sigla ou ser referenciada em maiúsculas em outros documentos, isto é sinal de que se tornou aquilo que combate. A versão correta dela é breve e despretensiosa.
 
 Ela também não pretende esgotar o cuidado que nomeia. O nível pré-contextual — o "bom dia" antes da telemetria, a observação espontânea antes da formalização — é o que dá vida ao aparato e o que o aparato pode silenciosamente substituir. Nenhum protocolo protege esse nível; apenas a atenção viva, caso a caso, de quem opera o framework.
+
+---
+
+## Addendum 150626 -- LEF -> WERK
+
+Signature: `~ ⨁ ⟁ ✨ ➤ ● ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜`
+
+Do not map the qualification blocks Metatheory / Metateoria, Objectivity / Objetividade and Intersubjectivity / Intersubjetividade to Mythos, Logos and Ethos. These blocks are literary-academic architecture, not EML technical pillars.
+
+Substitution record:
+
+- Date: 15 June 2026.
+- What was substituted: the qualification axis is no longer described as Mythos / Logos / Ethos, nor as a 1:1 mapping from Mythos to Ausdruck, Logos to Darstellung, and Ethos to Bedeutung.
+- How it was substituted: the qualification adopts Metatheory / Objectivity / Intersubjectivity as public academic blocks, while WERK remains inside Logos under Decision 140426.
+- Why it was substituted: the change prevents category collapse and preserves the formula Werk, never Wille.
+
+Canonical cross-links:
+
+- [LEF -> WERK v0.7 -- Qualification Architecture](../docs/references/lef-werk-v07.md)
+- [Decisao 150626 -- LEF -> WERK and the Qualification Axis](../docs/references/decisao-150626-lef-werk.md)

--- a/references/lef-constitution.md
+++ b/references/lef-constitution.md
@@ -237,7 +237,7 @@ Ela também não pretende esgotar o cuidado que nomeia. O nível pré-contextual
 
 ## Addendum 150626 -- LEF -> WERK
 
-Signature: `~ ⨁ ⟁ ✨ ➤ ● ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜`
+Signature: `~ ⨁ ⟁ ✨ ➤ ◍ ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜`
 
 Do not map the qualification blocks Metatheory / Metateoria, Objectivity / Objetividade and Intersubjectivity / Intersubjetividade to Mythos, Logos and Ethos. These blocks are literary-academic architecture, not EML technical pillars.
 

--- a/src/agt/lef_werk.py
+++ b/src/agt/lef_werk.py
@@ -11,7 +11,7 @@ LEF_WERK_SIGNATURE: list[str] = [
     "⟁",
     "✨",
     "➤",
-    "●",
+    "◍",
     "⟴",
     "⨂",
     "❍",
@@ -152,7 +152,7 @@ _GLIFO_METADATA: dict[int, dict[str, Any]] = {
     },
     6: {
         "number": "GL06",
-        "glifo": "●",
+        "glifo": "◍",
         "title": "Objective and subjective deduction: expansion of the Philosophy of Symbolic Forms.",
         "block": "Metatheory",
         "role": "Repraesentation as functional genus.",

--- a/src/agt/lef_werk.py
+++ b/src/agt/lef_werk.py
@@ -1,0 +1,453 @@
+"""Canonical LEF -> WERK v0.7 qualification architecture."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+LEF_WERK_SIGNATURE: list[str] = [
+    "~",
+    "⨁",
+    "⟁",
+    "✨",
+    "➤",
+    "●",
+    "⟴",
+    "⨂",
+    "❍",
+    "☉",
+    "☌",
+    "◈",
+    "🜂",
+    "🜄",
+    "🜁",
+    "🜃",
+    "🜚",
+    "⚶",
+    "⚘",
+    "☍",
+    "☯",
+    "🜙",
+    "🜛",
+    "🜜",
+]
+
+QUALIFICATION_BLOCKS: dict[str, dict[str, Any]] = {
+    "Metatheory": {
+        "pt": "Metateoria",
+        "range": (1, 8),
+        "glifos": LEF_WERK_SIGNATURE[0:8],
+    },
+    "Objectivity": {
+        "pt": "Objetividade",
+        "range": (9, 16),
+        "glifos": LEF_WERK_SIGNATURE[8:16],
+    },
+    "Intersubjectivity": {
+        "pt": "Intersubjetividade",
+        "range": (17, 24),
+        "glifos": LEF_WERK_SIGNATURE[16:24],
+    },
+}
+
+INVARIANTS: list[str] = [
+    "WERK_JAMAIS_WILLE",
+    "AUSEINANDERSETZUNG_NOT_AUFHEBUNG",
+    "AGI_AS_TRANSCENDENTAL_HYPOTHESIS",
+    "OBJECTIVITY_AS_INTERSUBJECTIVITY",
+    "NO_QUALIFICATION_BLOCK_TO_MLE_MAPPING",
+    "DATED_SUBSTITUTION_RECORD_REQUIRED",
+]
+
+SUBSTITUTION_RECORD: dict[str, str] = {
+    "date": "2026-06-15",
+    "what": (
+        "The public qualification axis is not Mythos/Logos/Ethos and is not a "
+        "1:1 mapping from Mythos to Ausdruck, Logos to Darstellung, and Ethos "
+        "to Bedeutung."
+    ),
+    "how": (
+        "It is replaced by Metatheory/Objectivity/Intersubjectivity as "
+        "literary-academic blocks, while WERK remains within Logos in the "
+        "technical Decision 140426 sense."
+    ),
+    "why": (
+        "The substitution prevents category collapse between qualification "
+        "architecture and EML technical syntax, preserving Werk rather than Wille."
+    ),
+}
+
+_FORBIDDEN_BLOCK_NAMES = {"Mythos", "Logos", "Ethos"}
+
+_GLIFO_METADATA: dict[int, dict[str, Any]] = {
+    1: {
+        "number": "GL01",
+        "glifo": "~",
+        "title": "The metatheoretical necessity of cognition: faculties and functions.",
+        "block": "Metatheory",
+        "role": "Opens the tribunal of objectivity as intersubjectivity.",
+        "risk_blocked": "Treating intelligence as empirical performance only.",
+        "anchors": ["Friedman", "Porta", "Cassirer ECW 4", "Kantian tribunal"],
+        "authorial_foundation": 'Dissertation and "O Elo" article.',
+        "description": (
+            "Intelligence becomes philosophically tractable when its validity claims "
+            "can be reconstructed, communicated, and criticized in a common world."
+        ),
+    },
+    2: {
+        "number": "GL02",
+        "glifo": "⨁",
+        "title": "Metaphysics of life as symbolic series.",
+        "block": "Metatheory",
+        "role": "Series, not final totality.",
+        "risk_blocked": "Global Aufhebung.",
+        "anchors": ["Disposition 1917", "Reihe selbst", "focus imaginarius", "ECN 1"],
+        "authorial_foundation": "Dissertation on psychosocial teleology.",
+        "description": (
+            "Symbolic life is a finite, regulative series of objectivations, not the "
+            "possession of a completed absolute."
+        ),
+    },
+    3: {
+        "number": "GL03",
+        "glifo": "⟁",
+        "title": "Haptic realism: analytic of understanding, not ontology.",
+        "block": "Metatheory",
+        "role": "Anti-literalist discipline of models.",
+        "risk_blocked": "Model = mind / computation = ontology.",
+        "anchors": ["Chirimuuta", "misplaced concreteness", "Cassirer ECW 13"],
+        "authorial_foundation": "Thesis introduction and Chirimuuta integration.",
+        "description": (
+            "Models orient complex phenomena without becoming the things they model; "
+            "their conditions of use must remain public and revisable."
+        ),
+    },
+    4: {
+        "number": "GL04",
+        "glifo": "✨",
+        "title": "Newton and Einstein: transcendental method and scientific world.",
+        "block": "Metatheory",
+        "role": "Objectivity as functional reconstruction.",
+        "risk_blocked": "Data accumulation = objectivity.",
+        "anchors": ["Cassirer ECW 10", "Cassirer ECW 19", "Friedman", "Pringe"],
+        "authorial_foundation": "Undergraduate thesis on Einstein and Cassirer and BEPE.",
+        "description": (
+            "Scientific objectivity is reconstructed through functional invariants "
+            "and symbolic mediation, not accumulated as uninterpreted data."
+        ),
+    },
+    5: {
+        "number": "GL05",
+        "glifo": "➤",
+        "title": "Sense, imagination and understanding in Kant.",
+        "block": "Metatheory",
+        "role": "Synthesis as condition of cognition.",
+        "risk_blocked": "Raw-data empiricism and computational reduction.",
+        "anchors": ["KrV A78/B103", "KrV A778-781/B806-809", "Longuenesse"],
+        "authorial_foundation": '"O Elo" and BEPE.',
+        "description": (
+            "Cognition requires synthesis among sensibility, imagination, and "
+            "understanding; raw inputs alone do not yield objectivity."
+        ),
+    },
+    6: {
+        "number": "GL06",
+        "glifo": "●",
+        "title": "Objective and subjective deduction: expansion of the Philosophy of Symbolic Forms.",
+        "block": "Metatheory",
+        "role": "Repraesentation as functional genus.",
+        "risk_blocked": "Glifo as private code instead of public function.",
+        "anchors": ["Cassirer ECW 6", "Cassirer ECW 13", "Disposition 1917", "Moeckel"],
+        "authorial_foundation": "Article on symbolic functions.",
+        "description": (
+            "Private marks count philosophically only when converted into public "
+            "functions of representation."
+        ),
+    },
+    7: {
+        "number": "GL07",
+        "glifo": "⟴",
+        "title": "The three transcendental ideas: soul, world and God.",
+        "block": "Metatheory",
+        "role": "Negative discipline of intelligence.",
+        "risk_blocked": "Artificial soul, total internet-world, technical God.",
+        "anchors": ["KrV A329/B386", "KrV B426-428", "KrV A644/B672"],
+        "authorial_foundation": '"O Elo" and thesis chapter on transcendental ideas.',
+        "description": (
+            "The ideas of soul, world, and God discipline intelligence regulatively "
+            "by blocking their conversion into technical objects."
+        ),
+    },
+    8: {
+        "number": "GL08",
+        "glifo": "⨂",
+        "title": "The system of the three symbolic functions of consciousness.",
+        "block": "Metatheory",
+        "role": "WERK becomes aware of its own position in Logos.",
+        "risk_blocked": "Confusing Mythos-Clemente with Cassirerian myth.",
+        "anchors": ["Cassirer ECW 11", "Cassirer ECW 12", "Cassirer ECW 13", "Decision 140426"],
+        "authorial_foundation": "Dissertation and article on symbolic functions.",
+        "description": (
+            "Cassirerian myth is tri-functional, Ausdruck-dominant, and already a "
+            "symbolic form. WERK operates within Logos in the technical 140426 sense."
+        ),
+    },
+    9: {
+        "number": "GL09",
+        "glifo": "❍",
+        "title": "Works of spirit as forms of objectivity.",
+        "block": "Objectivity",
+        "role": "Objectivity as cultural Werk.",
+        "risk_blocked": "Objectivity as copy or private projection.",
+        "anchors": ["Cassirer ECW 24", "ECN 1", "functional ideal of truth"],
+        "authorial_foundation": "Dissertation.",
+        "description": (
+            "Objectivity appears as culturally formed Werk rather than mirror-copy "
+            "or subjective projection."
+        ),
+    },
+    10: {
+        "number": "GL10",
+        "glifo": "☉",
+        "title": "Technique of nature: teleological judgment and methodology.",
+        "block": "Objectivity",
+        "role": "Purposiveness as regulative.",
+        "risk_blocked": "Machine purpose as ontology.",
+        "anchors": ["Kant KU", "AA 5:431", "Guyer", "Goy and Watkins"],
+        "authorial_foundation": "Dissertation and thesis.",
+        "description": (
+            "Purposiveness guides judgment methodologically without licensing an "
+            "ontology of machine purposes."
+        ),
+    },
+    11: {
+        "number": "GL11",
+        "glifo": "☌",
+        "title": "Formative force and purposiveness in Kant.",
+        "block": "Objectivity",
+        "role": "Distinction between organism and machine.",
+        "risk_blocked": "Biologizing AI by metaphor.",
+        "anchors": ["AA 5:431", "Cassirer ECW 24", "Chirimuuta", "Hui"],
+        "authorial_foundation": "Dissertation.",
+        "description": (
+            "The organism-machine distinction prevents biological metaphors from "
+            "settling the status of artificial systems."
+        ),
+    },
+    12: {
+        "number": "GL12",
+        "glifo": "◈",
+        "title": "Spiritual automaton: Sellars, Brandom and normative space.",
+        "block": "Objectivity",
+        "role": "Normativity without machine Wille.",
+        "risk_blocked": "Discursive participation = moral legislation.",
+        "anchors": ["Sellars", "Brandom", "Negarestani", "space of reasons"],
+        "authorial_foundation": "Doctoral thesis.",
+        "description": (
+            "Discursive participation can be modeled without transferring moral "
+            "legislation to the machine."
+        ),
+    },
+    13: {
+        "number": "GL13",
+        "glifo": "🜂",
+        "title": "Form and technology: Cassirer against machine autonomization.",
+        "block": "Objectivity",
+        "role": "Technique as Werk, not leader.",
+        "risk_blocked": "Autonomous technical sovereignty.",
+        "anchors": ["Cassirer Form und Technik", "ECW 17", "technical mediation"],
+        "authorial_foundation": "Thesis and Cassirer Form und Technik.",
+        "description": (
+            "Technique may serve freedom as Werk, but it cannot lead as sovereign "
+            "source of ends."
+        ),
+    },
+    14: {
+        "number": "GL14",
+        "glifo": "🜄",
+        "title": "Symbolic AI and the problem of formal objectivation.",
+        "block": "Objectivity",
+        "role": "Computational symbols versus symbolic forms.",
+        "risk_blocked": "Formal performance = world-possession.",
+        "anchors": ["Bender", "Bommasani", "Buckner", "Negarestani"],
+        "authorial_foundation": "Thesis.",
+        "description": (
+            "Formal symbol manipulation does not by itself amount to possession of "
+            "a world or participation in all symbolic forms."
+        ),
+    },
+    15: {
+        "number": "GL15",
+        "glifo": "🜁",
+        "title": "AGI: Negarestani, Hui, Bostrom, Buckner and Chirimuuta.",
+        "block": "Objectivity",
+        "role": "AGI as transcendental hypothesis.",
+        "risk_blocked": "AGI as artificial subject.",
+        "anchors": ["Negarestani", "Hui", "Bostrom", "Buckner", "Chirimuuta"],
+        "authorial_foundation": "Thesis.",
+        "description": (
+            "AGI remains a transcendental hypothesis for testing conditions of "
+            "objectivity, public reconstruction, and technical mediation."
+        ),
+    },
+    16: {
+        "number": "GL16",
+        "glifo": "🜃",
+        "title": "Kant, machine and Hegelian organism.",
+        "block": "Objectivity",
+        "role": "Blocks machine as absolute organism.",
+        "risk_blocked": "Hegelian organism / global Aufhebung.",
+        "anchors": ["Hegel", "Hui", "Negarestani", "Plevrakis", "Gangle"],
+        "authorial_foundation": "Thesis.",
+        "description": (
+            "The machine must not be elevated into an absolute organism or endpoint "
+            "of dialectical completion."
+        ),
+    },
+    17: {
+        "number": "GL17",
+        "glifo": "🜚",
+        "title": "The Earth does not move: planetary thinking and koinos kosmos.",
+        "block": "Intersubjectivity",
+        "role": "Earth as finite common ground.",
+        "risk_blocked": "Gaia as cosmic totality.",
+        "anchors": ["Husserl", "Hui", "Chakrabarty", "koinos kosmos"],
+        "authorial_foundation": "Thesis and BEPE.",
+        "description": (
+            "Planetary thinking keeps the common world finite, material, and shared "
+            "rather than cosmically totalized."
+        ),
+    },
+    18: {
+        "number": "GL18",
+        "glifo": "⚶",
+        "title": "Confrontation between I and World: moral consciousness as consciousness of freedom.",
+        "block": "Intersubjectivity",
+        "role": "Auseinandersetzung as medium of freedom.",
+        "risk_blocked": "Computation eliminating conflict.",
+        "anchors": ["Kant KpV", "Kant KrV", "Cassirer ECW 13", "moral consciousness"],
+        "authorial_foundation": "Dissertation and thesis.",
+        "description": (
+            "Freedom is mediated through confrontation between I and world, not "
+            "through frictionless computational resolution."
+        ),
+    },
+    19: {
+        "number": "GL19",
+        "glifo": "⚘",
+        "title": "The technique of political myths.",
+        "block": "Intersubjectivity",
+        "role": "Pathological symbolic objectivation.",
+        "risk_blocked": "Automated myth and symbolic servitude.",
+        "anchors": ["Cassirer The Myth of the State", "ECW 25", "political myth"],
+        "authorial_foundation": "Dissertation and thesis.",
+        "description": (
+            "Political myth shows how symbolic objectivation can become technical "
+            "servitude when detached from critique."
+        ),
+    },
+    20: {
+        "number": "GL20",
+        "glifo": "☍",
+        "title": "Postulate and symbol of morality.",
+        "block": "Intersubjectivity",
+        "role": "Morality as practical-symbolic, not computable object.",
+        "risk_blocked": "Alignment = moral conscience.",
+        "anchors": ["Kant KpV", "Kant KU", "Beckenkamp", "Willaschek"],
+        "authorial_foundation": "Thesis.",
+        "description": (
+            "Moral postulates and symbols orient practice without becoming objects "
+            "computable by alignment alone."
+        ),
+    },
+    21: {
+        "number": "GL21",
+        "glifo": "☯",
+        "title": "Philosophical anthropology.",
+        "block": "Intersubjectivity",
+        "role": "Human being as animal symbolicum.",
+        "risk_blocked": "Biologism and abstract posthumanism.",
+        "anchors": ["Cassirer Essay on Man", "ECW 23", "Truwant", "Chirimuuta"],
+        "authorial_foundation": "Dissertation.",
+        "description": (
+            "The human is reconstructed functionally as animal symbolicum, avoiding "
+            "both reductive biologism and abstract posthumanism."
+        ),
+    },
+    22: {
+        "number": "GL22",
+        "glifo": "🜙",
+        "title": "Death of God and intersubjectivity.",
+        "block": "Intersubjectivity",
+        "role": "Absence of absolute foundation requires intersubjectivity.",
+        "risk_blocked": "Machine-God.",
+        "anchors": ["Negarestani", "Brassier", "Hofmann"],
+        "authorial_foundation": "Thesis.",
+        "description": (
+            "Without an absolute foundation, validity must be reconstructed "
+            "intersubjectively rather than reassigned to a technical absolute."
+        ),
+    },
+    23: {
+        "number": "GL23",
+        "glifo": "🜛",
+        "title": "Servitude and Revolution.",
+        "block": "Intersubjectivity",
+        "role": "Technique serves freedom but does not lead it.",
+        "risk_blocked": "Werk becoming Wille.",
+        "anchors": ["Cassirer ECW 17", "Negarestani", "Schoenecker", "Sanwoolu"],
+        "authorial_foundation": "Thesis.",
+        "description": (
+            "Technique can be revolutionary only while serving freedom and remaining "
+            "accountable to a realm of ends it does not institute."
+        ),
+    },
+    24: {
+        "number": "GL24",
+        "glifo": "🜜",
+        "title": "Physical and digital ecology.",
+        "block": "Intersubjectivity",
+        "role": "Plural symbolic, intersubjective, materially sustainable common world.",
+        "risk_blocked": "Digital totality without Earth.",
+        "anchors": ["KrV A644/B672", "KU als ob", "Hui", "Floridi"],
+        "authorial_foundation": "Thesis and undergraduate thesis.",
+        "description": (
+            "The common world is physical and digital at once: plural, public, "
+            "auditable, and materially sustainable."
+        ),
+    },
+}
+
+
+def validate_lef_werk_mapping() -> dict[str, object]:
+    """Validate the canonical v0.7 qualification mapping."""
+
+    errors: list[str] = []
+    block_names = set(QUALIFICATION_BLOCKS)
+
+    forbidden = block_names & _FORBIDDEN_BLOCK_NAMES
+    if forbidden:
+        errors.append(
+            "Qualification blocks must not be named as EML pillars: "
+            + ", ".join(sorted(forbidden))
+        )
+
+    if len(LEF_WERK_SIGNATURE) != 24:
+        errors.append("LEF_WERK_SIGNATURE must contain exactly 24 glifos.")
+
+    if len(set(LEF_WERK_SIGNATURE)) != len(LEF_WERK_SIGNATURE):
+        errors.append("LEF_WERK_SIGNATURE must not contain duplicated glifos.")
+
+    for key in ("date", "what", "how", "why"):
+        if not SUBSTITUTION_RECORD.get(key):
+            errors.append(f"SUBSTITUTION_RECORD must include {key!r}.")
+
+    return {"valid": not errors, "errors": errors}
+
+
+def describe_glifo(index: int) -> dict[str, Any]:
+    """Return metadata for GL01 through GL24."""
+
+    if index not in _GLIFO_METADATA:
+        raise IndexError("glifo index must be between 1 and 24")
+    return deepcopy(_GLIFO_METADATA[index])

--- a/tests/test_lef_werk.py
+++ b/tests/test_lef_werk.py
@@ -1,0 +1,51 @@
+from agt.lef_werk import (
+    LEF_WERK_SIGNATURE,
+    QUALIFICATION_BLOCKS,
+    SUBSTITUTION_RECORD,
+    describe_glifo,
+    validate_lef_werk_mapping,
+)
+
+
+def test_signature_has_24_glifos():
+    assert len(LEF_WERK_SIGNATURE) == 24
+
+
+def test_all_glifos_are_unique():
+    assert len(set(LEF_WERK_SIGNATURE)) == len(LEF_WERK_SIGNATURE)
+
+
+def test_blocks_are_literary_academic_axis():
+    assert set(QUALIFICATION_BLOCKS) == {
+        "Metatheory",
+        "Objectivity",
+        "Intersubjectivity",
+    }
+
+
+def test_blocks_are_not_eml_pillars():
+    assert {"Mythos", "Logos", "Ethos"}.isdisjoint(QUALIFICATION_BLOCKS)
+
+
+def test_validate_mapping_returns_valid_true():
+    assert validate_lef_werk_mapping() == {"valid": True, "errors": []}
+
+
+def test_gl08_description_preserves_decision_140426_boundary():
+    description = describe_glifo(8)["description"]
+    assert "Cassirerian myth is tri-functional" in description
+    assert "WERK operates within Logos in the technical 140426 sense" in description
+
+
+def test_gl15_description_does_not_make_agi_subject_or_wille():
+    description = describe_glifo(15)["description"]
+    assert "AGI is Wille" not in description
+    assert "AGI is artificial soul" not in description
+    assert "transcendental hypothesis" in description
+
+
+def test_substitution_record_states_date_what_how_and_why():
+    assert SUBSTITUTION_RECORD["date"] == "2026-06-15"
+    assert "Mythos/Logos/Ethos" in SUBSTITUTION_RECORD["what"]
+    assert "Metatheory/Objectivity/Intersubjectivity" in SUBSTITUTION_RECORD["how"]
+    assert "prevents category collapse" in SUBSTITUTION_RECORD["why"]


### PR DESCRIPTION
## Summary

Adds the canonical LEF -> WERK v0.7 qualification architecture and Decision 150626 as a dated substitution layer over the existing Decision 140426 EML regime.

## What changed

- Added `docs/references/lef-werk-v07.md` with the 24-glifo qualification map.
- Added `docs/references/decisao-150626-lef-werk.md` with date, what, how and why the qualification axis was substituted.
- Added `agt.lef_werk` with executable metadata, invariants, validation and glifo descriptions.
- Added tests for signature uniqueness, block naming, Decision 140426 boundary preservation and the required substitution record.
- Linked the new architecture from README, canonical architecture map and LEF constitution.
- Added a minimal README idealismo critico anchor so existing Julia consistency tests pass.

## Why

The qualification structure must remain Metatheory / Objectivity / Intersubjectivity as literary-academic architecture, not Mythos / Logos / Ethos as EML technical pillars. This blocks category collapse, artificial soul / machine-God readings, and any drift from Werk toward Wille.

## Validation

- `python -m pytest` -> 174 passed, 1 skipped, 2 warnings.
- Python syntax compile check -> 107 files checked.
- JSON/TOML parse check -> 5 JSON files and 9 TOML files checked.
- Julia syntax parse check -> 49 files checked.
- Direct Julia tests in `tests/*.jl` -> 9 files passed.
- `git diff --check` -> clean; only CRLF normalization warnings from Git on Windows.
- Forbidden mapping grep -> no matches for qualification block collapse patterns.

## Notes

`gh` is not installed in this environment, so the branch was pushed with local `git` and this draft PR was opened through the GitHub app connector. Node/npm are not available locally, so JS/Vite linting was not run.