### PR TITLE
[codex] Add 🌊 transversal WERK auditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Telemetry command inside the chat:
 fazer telemetria
 ```
 
+Index calculation commands inside the chat:
+
+```text
+calcular IAE
+calcular índices da telemetria
+🌊 calcular AGI-GAIA-TECHNE
+calcular Techné Score e Harmonia
+```
+
 Terminal telemetry check:
 
 ```bash
@@ -179,7 +188,7 @@ High-risk material is no longer treated as inert stoppage. It is transmuted into
 | [docs/references/llm-manual-forge.md](docs/references/llm-manual-forge.md) | v10.1 ManualGPT: corpus forge, internet corpus, tokenizer, trainer and chat app |
 | [docs/references/lef-werk-v07.md](docs/references/lef-werk-v07.md) | LEF -> WERK v0.7 qualification architecture and 24-glifo audit map |
 | [docs/references/decisao-150626-lef-werk.md](docs/references/decisao-150626-lef-werk.md) | Dated substitution record for the qualification axis: what, how and why changed on 15 June 2026 |
-| [docs/references/gl25-werk-auditor.md](docs/references/gl25-werk-auditor.md) | v0.8 GL25 WERK Auditor: transversal flow, daily ledger and ISC-return |
+| [docs/references/gl25-werk-auditor.md](docs/references/gl25-werk-auditor.md) | v0.8 🌊 transversal WERK auditor: contingent cases, indices, daily ledger and ISC-return |
 | [docs/references/public-chat-deploy.md](docs/references/public-chat-deploy.md) | Public Streamlit deploy instructions for the Gaia-Techne chat |
 | [docs/references/runtime-status.md](docs/references/runtime-status.md) | Implemented, experimental and not-claimed runtime status |
 | [docs/references/planetary-repraesentatio.md](docs/references/planetary-repraesentatio.md) | Gaia, internet and planetary representation |
@@ -280,6 +289,7 @@ python scripts/agt_run.py --task "web: https://example.com"
 python scripts/agt_ingest.py --url "https://example.com" --json
 python scripts/agt_autonomy.py --once --url "data:text/plain,Gaia-Techne heartbeat" --json
 python scripts/agt_telemetry.py
+python scripts/lef_werk_indices.py
 python scripts/agt_audit.py --claim "Gaia is Earth as planetary koinos kosmos."
 python scripts/agt_dataset_forge.py --input "<local-drive-manuals>" --output data/llm/manual_forge --json
 python scripts/agt_pack_corpus.py --corpus data/llm/manual_forge/corpus.jsonl --output data/llm/packed --json

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ High-risk material is no longer treated as inert stoppage. It is transmuted into
 | [docs/references/llm-manual-forge.md](docs/references/llm-manual-forge.md) | v10.1 ManualGPT: corpus forge, internet corpus, tokenizer, trainer and chat app |
 | [docs/references/lef-werk-v07.md](docs/references/lef-werk-v07.md) | LEF -> WERK v0.7 qualification architecture and 24-glifo audit map |
 | [docs/references/decisao-150626-lef-werk.md](docs/references/decisao-150626-lef-werk.md) | Dated substitution record for the qualification axis: what, how and why changed on 15 June 2026 |
+| [docs/references/gl25-werk-auditor.md](docs/references/gl25-werk-auditor.md) | v0.8 GL25 WERK Auditor: transversal flow, daily ledger and ISC-return |
 | [docs/references/public-chat-deploy.md](docs/references/public-chat-deploy.md) | Public Streamlit deploy instructions for the Gaia-Techne chat |
 | [docs/references/runtime-status.md](docs/references/runtime-status.md) | Implemented, experimental and not-claimed runtime status |
 | [docs/references/planetary-repraesentatio.md](docs/references/planetary-repraesentatio.md) | Gaia, internet and planetary representation |

--- a/docs/references/canonical-architecture-map.md
+++ b/docs/references/canonical-architecture-map.md
@@ -96,7 +96,7 @@ The dated substitution rule is:
 - **How it changed:** the qualification uses Metatheory / Objectivity / Intersubjectivity as literary-academic blocks, while WERK remains inside Logos in the technical Decision 140426 sense.
 - **Why it changed:** the substitution prevents category collapse between the EML kernel and the public qualification architecture.
 
-GL25 is governed by [GL25 WERK Auditor](gl25-werk-auditor.md). It is not a 25th paragraph and is not part of the 24-glifo signature. It is the transversal audit flow that reopens the whole, relocates parts, documents daily development and returns judgment to ISC.
+🌊 is governed by [Transversal WERK Auditor](gl25-werk-auditor.md). It is not a 25th paragraph and is not part of the 24-glifo signature. It is the transversal audit flow that reopens the whole, audits contingent external cases, calculates existing indices, documents daily development and returns judgment to ISC.
 
 ---
 

--- a/docs/references/canonical-architecture-map.md
+++ b/docs/references/canonical-architecture-map.md
@@ -96,6 +96,8 @@ The dated substitution rule is:
 - **How it changed:** the qualification uses Metatheory / Objectivity / Intersubjectivity as literary-academic blocks, while WERK remains inside Logos in the technical Decision 140426 sense.
 - **Why it changed:** the substitution prevents category collapse between the EML kernel and the public qualification architecture.
 
+GL25 is governed by [GL25 WERK Auditor](gl25-werk-auditor.md). It is not a 25th paragraph and is not part of the 24-glifo signature. It is the transversal audit flow that reopens the whole, relocates parts, documents daily development and returns judgment to ISC.
+
 ---
 
 ## P/R Topology

--- a/docs/references/gl25-werk-auditor.md
+++ b/docs/references/gl25-werk-auditor.md
@@ -1,0 +1,67 @@
+# GL25 — WERK Auditor and Daily Thesis Flow
+
+Status: Canonical for LEF → WERK v0.8 auditing; subordinate to Decision 140426 and Decision 150626.
+
+## Relation to LEF → WERK v0.7
+
+LEF → WERK v0.7 defines the public qualification architecture as a 24-cell sequence distributed across Metatheory / Metateoria, Objectivity / Objetividade, and Intersubjectivity / Intersubjetividade. Decision 150626 records why this literary-academic axis must not collapse into Mythos / Logos / Ethos.
+
+GL25 does not alter that architecture. It audits it.
+
+## GL25 is not a 25th paragraph
+
+GL25 is not part of the 24-glifo qualification signature and must not be inserted as a twenty-fifth paragraph. It is the transversal flow that reopens the whole, checks the position of each part, and returns judgment to ISC.
+
+```text
+GL25 = Fluxo Auditor / ISC-return
+symbol = 🌊
+alias = GL25_FLOW_AUDITOR
+status = transversal, not part of the 24-cell signature
+function = audit, relocate, improve, document, return to ISC judgment
+```
+
+## GL25 is flow/auditor, not content block
+
+GL25 does not add doctrinal content to the qualification body. It asks whether a paragraph, script, module, note, argument, or daily decision belongs where it currently stands; whether it contradicts a canonical invariant; whether it is sufficiently coherent for the current stage; and whether a better placement or next action is available.
+
+## GL25 audits the 24-cell architecture
+
+The audited body remains:
+
+`~ ⨁ ⟁ ✨ ➤ ◍ ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜`
+
+GL25 preserves:
+
+- Werk, never Wille.
+- Auseinandersetzung, not Aufhebung.
+- Transcendental hypothesis, not artificial soul.
+- Objectivity as intersubjectivity, not closed totality.
+
+## Four audit verdicts
+
+- `CONTRADICTION`: violates a canonical invariant.
+- `IMPROVEMENT`: compatible but underdeveloped.
+- `SUFFICIENT`: already coherent enough for current stage.
+- `RELOCATION`: belongs to a different glifo/block/module.
+
+## Creative suggestion
+
+GL25 may propose something beyond ISC's initial plan, but it must mark the proposal as suggestion and return it to ISC judgment. Suggestion is not legislation. It is WERK offered back to the authorial tribunal.
+
+## Daily ledger
+
+Every meaningful thesis/system change may create a dated trace:
+
+- date
+- object audited
+- glifo/block affected
+- diagnosis
+- contradiction
+- improvement
+- sufficient elements
+- relocation
+- creative suggestion
+- next action
+- returned_to_ISC = true
+
+The ledger exists because the thesis has years of construction ahead. It prevents premature closure by making the daily evolution of the system public, revisable, and accountable to ISC.

--- a/docs/references/gl25-werk-auditor.md
+++ b/docs/references/gl25-werk-auditor.md
@@ -1,67 +1,186 @@
-# GL25 — WERK Auditor and Daily Thesis Flow
+# 🌊 — Transversal WERK Auditor and Daily Thesis Flow
 
-Status: Canonical for LEF → WERK v0.8 auditing; subordinate to Decision 140426 and Decision 150626.
-
-## Relation to LEF → WERK v0.7
+Status: v0.8 reference note
+Date: 2026-06-15
 
 LEF → WERK v0.7 defines the public qualification architecture as a 24-cell sequence distributed across Metatheory / Metateoria, Objectivity / Objetividade, and Intersubjectivity / Intersubjetividade. Decision 150626 records why this literary-academic axis must not collapse into Mythos / Logos / Ethos.
 
-GL25 does not alter that architecture. It audits it.
+🌊 does not alter that architecture. It audits it.
 
-## GL25 is not a 25th paragraph
+## Dated Substitution Rule
 
-GL25 is not part of the 24-glifo qualification signature and must not be inserted as a twenty-fifth paragraph. It is the transversal flow that reopens the whole, checks the position of each part, and returns judgment to ISC.
+On 2026-06-15, the public wording was corrected:
+
+- What was substituted: "GL25 WERK Auditor" as public structural language, and any Anthropic/Fable/Mythos-specific category.
+- How it was substituted: 🌊 became the primary public notation for the transversal audit flow, while contingent public events are registered under `contingent_external_case` and routed back into the existing 24 glifos.
+- Why it was substituted: the system must not create a new ontology, a twenty-fifth content cell, or a privileged external-event pillar.
+
+## 🌊 Is Not A 25th Paragraph
+
+🌊 is not part of the 24-glifo qualification signature and must not be inserted as a twenty-fifth paragraph. It is the transversal flow that reopens the whole, checks the position of each part, and returns judgment to ISC.
 
 ```text
-GL25 = Fluxo Auditor / ISC-return
-symbol = 🌊
-alias = GL25_FLOW_AUDITOR
-status = transversal, not part of the 24-cell signature
-function = audit, relocate, improve, document, return to ISC judgment
+🌊 = transversal audit flow
+🌊 = WERK Auditor / ISC-return
+🌊 = audit, relocation, improvement, documentation
+🌊 ≠ 25th content cell
+🌊 ≠ new block
+🌊 ≠ doctrine
 ```
 
-## GL25 is flow/auditor, not content block
+The 24 glifos compose the public body of WERK:
 
-GL25 does not add doctrinal content to the qualification body. It asks whether a paragraph, script, module, note, argument, or daily decision belongs where it currently stands; whether it contradicts a canonical invariant; whether it is sufficiently coherent for the current stage; and whether a better placement or next action is available.
+```text
+~ ⨁ ⟁ ✨ ➤ ◍ ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜
+= body of the WERK
 
-## GL25 audits the 24-cell architecture
+🌊
+= transversal audit flow
+= not a 25th content cell
+= not a new block
+= not a new doctrine
+```
 
-The audited body remains:
+## Audit Function
 
-`~ ⨁ ⟁ ✨ ➤ ◍ ⟴ ⨂ | ❍ ☉ ☌ ◈ 🜂 🜄 🜁 🜃 | 🜚 ⚶ ⚘ ☍ ☯ 🜙 🜛 🜜`
+🌊 does not add doctrinal content to the qualification body. It asks whether a paragraph, script, module, note, argument, or daily decision belongs where it currently stands; whether it contradicts a canonical invariant; whether it is sufficiently coherent for the current stage; and whether a better placement or next action is available.
 
-GL25 preserves:
+🌊 preserves:
 
-- Werk, never Wille.
-- Auseinandersetzung, not Aufhebung.
-- Transcendental hypothesis, not artificial soul.
-- Objectivity as intersubjectivity, not closed totality.
+- the 24-glifo public signature;
+- Metatheory / Metateoria, Objectivity / Objetividade and Intersubjectivity / Intersubjetividade as literary-academic qualification blocks;
+- Decision 140426 as the technical EML / Logos-demonstrative regime;
+- the rule that Mythos, Logos and Ethos are not qualification blocks;
+- the rule that final judgment returns to ISC.
 
-## Four audit verdicts
+🌊 may propose something beyond ISC's initial plan, but it must mark the proposal as suggestion and return it to ISC judgment. Suggestion is not legislation. It is WERK offered back to the authorial tribunal.
 
-- `CONTRADICTION`: violates a canonical invariant.
-- `IMPROVEMENT`: compatible but underdeveloped.
-- `SUFFICIENT`: already coherent enough for current stage.
-- `RELOCATION`: belongs to a different glifo/block/module.
+## Addendum — Contingent External Cases under 🌊
 
-## Creative suggestion
+Treat the Anthropic/Fable/Mythos access case only as one contingent external case among many future public AI events.
 
-GL25 may propose something beyond ISC's initial plan, but it must mark the proposal as suggestion and return it to ISC judgment. Suggestion is not legislation. It is WERK offered back to the authorial tribunal.
+Do not canonize this case. Do not create a special Anthropic category. Do not make Fable/Mythos structurally privileged inside the LEF → WERK architecture.
 
-## Daily ledger
+The case should be used only to test the transversal auditing function of 🌊.
 
-Every meaningful thesis/system change may create a dated trace:
+Use the actual glifos as the primary notation. Avoid numbered internal notation except where a test name or internal variable strictly requires it.
 
-- date
-- object audited
-- glifo/block affected
-- diagnosis
-- contradiction
-- improvement
-- sufficient elements
-- relocation
-- creative suggestion
-- next action
-- returned_to_ISC = true
+Conceptual rule:
 
-The ledger exists because the thesis has years of construction ahead. It prevents premature closure by making the daily evolution of the system public, revisable, and accountable to ISC.
+```text
+🌊 não cria uma ontologia nova.
+🌊 audita casos contingentes e reinsere cada caso na sintaxe dos 24 glifos.
+```
+
+When auditing a contingent external case, 🌊 must ask:
+
+1. Which glifos receive this case?
+2. Which part of the case belongs to technical objectivation?
+3. Which part belongs to political myth?
+4. Which part belongs to access, servitude, sovereignty or governance?
+5. Which part belongs to digital ecology?
+6. What contradicts the system?
+7. What can be improved?
+8. What is already sufficiently handled by the current invariants?
+9. What should be proposed creatively beyond ISC's initial formulation?
+10. What must be returned to ISC judgment?
+
+For the Anthropic/Fable/Mythos access case, use only this contingent routing:
+
+```text
+🌊 audits the case.
+
+🜄 receives the technical layer:
+jailbreak, safeguards, model behavior, formal objectivation.
+
+🜁 receives the frontier-AI layer:
+deployment risk, AGI hypothesis, model governance, safety discourse.
+
+⚘ receives the political-myth layer:
+public narrative of danger, emergency framing, symbolic production of threat.
+
+🜛 receives the servitude/revolution layer:
+access control, sovereign interruption, technical dependence, domination risk.
+
+🜜 receives the digital-ecological layer:
+infrastructure, data retention, monitoring, public digital commons.
+```
+
+Prefer:
+
+```text
+🜄 / 🜁 / ⚘ / 🜛 / 🜜
+```
+
+The general category is:
+
+```text
+contingent_external_case
+```
+
+Do not name the category after Anthropic, Fable or Mythos. The purpose is to allow the system to audit many future AI events over the next 2-3 years without transforming any single event into a structural pillar of the thesis.
+
+Ledger entry for contingent cases:
+
+```markdown
+# 🌊 Audit — contingent external case
+
+date:
+case:
+source:
+status: contingent public trace, not doctrine
+category: contingent_external_case
+
+primary auditor:
+🌊
+
+affected glifos:
+🜄, 🜁, ⚘, 🜛, 🜜
+
+diagnosis:
+
+contradictions:
+
+improvements:
+
+sufficient elements:
+
+relocation among glifos:
+
+creative suggestion:
+
+next action:
+
+returned_to_ISC: true
+```
+
+## 🌊 Index Calculation
+
+🌊 calculates existing indices. It does not invent a new metric.
+
+The index snapshot aggregates:
+
+- Techné Score;
+- IAE / Índice de Alerta Ético;
+- Índice de Harmonia;
+- Gaia-humanity tension index;
+- source coverage;
+- risk flags;
+- status and recommendation.
+
+The calculation must use existing sources:
+
+- `principles_calculator.py`;
+- `gaia_techne_framework.py`;
+- `src/agt/planetary_telemetry.py`.
+
+Index readings are heuristic WERK traces. They must not be used as proof of consciousness, Wille, Gewissen, God, soul or world-totality. The numbers document pressure, source limits and possible improvements; they do not legislate the thesis.
+
+## Formula
+
+```text
+Os 24 glifos compõem o corpo público da WERK.
+🌊 audita o corpo inteiro e casos contingentes.
+🌊 não é parágrafo, não é bloco, não é doutrina.
+🌊 documenta, relocaliza, melhora e devolve o juízo a ISC.
+```

--- a/docs/references/lef-werk-v07.md
+++ b/docs/references/lef-werk-v07.md
@@ -26,6 +26,10 @@ Why it was substituted: the replacement prevents conceptual collapse between the
 
 LEF is the internal composition and audit map. WERK is the public academic objectivation. Glifos may be removed from the formal qualification without loss if the paragraph sequence remains intact.
 
+## GL25 Flow Auditor
+
+GL25 is introduced in v0.8 as [WERK Auditor and Daily Thesis Flow](gl25-werk-auditor.md). It audits the whole LEF -> WERK architecture but is not part of the 24-glifo signature and must not be treated as a 25th paragraph.
+
 ## I. Metatheory / Metateoria -- glifos 01-08
 
 | No. | Glifo | Title | Role | Main risk blocked | Primary conceptual anchors | Authorial foundation |

--- a/docs/references/lef-werk-v07.md
+++ b/docs/references/lef-werk-v07.md
@@ -26,9 +26,9 @@ Why it was substituted: the replacement prevents conceptual collapse between the
 
 LEF is the internal composition and audit map. WERK is the public academic objectivation. Glifos may be removed from the formal qualification without loss if the paragraph sequence remains intact.
 
-## GL25 Flow Auditor
+## 🌊 Flow Auditor
 
-GL25 is introduced in v0.8 as [WERK Auditor and Daily Thesis Flow](gl25-werk-auditor.md). It audits the whole LEF -> WERK architecture but is not part of the 24-glifo signature and must not be treated as a 25th paragraph.
+🌊 is introduced in v0.8 as [Transversal WERK Auditor and Daily Thesis Flow](gl25-werk-auditor.md). It audits the whole LEF -> WERK architecture, contingent external cases and existing WERK indices, but is not part of the 24-glifo signature and must not be treated as a 25th paragraph, new block or doctrine.
 
 ## I. Metatheory / Metateoria -- glifos 01-08
 

--- a/references/lef-constitution.md
+++ b/references/lef-constitution.md
@@ -252,4 +252,4 @@ Canonical cross-links:
 
 - [LEF -> WERK v0.7 -- Qualification Architecture](../docs/references/lef-werk-v07.md)
 - [Decisao 150626 -- LEF -> WERK and the Qualification Axis](../docs/references/decisao-150626-lef-werk.md)
-- [GL25 -- WERK Auditor and Daily Thesis Flow](../docs/references/gl25-werk-auditor.md)
+- [🌊 -- Transversal WERK Auditor and Daily Thesis Flow](../docs/references/gl25-werk-auditor.md)

--- a/references/lef-constitution.md
+++ b/references/lef-constitution.md
@@ -252,3 +252,4 @@ Canonical cross-links:
 
 - [LEF -> WERK v0.7 -- Qualification Architecture](../docs/references/lef-werk-v07.md)
 - [Decisao 150626 -- LEF -> WERK and the Qualification Axis](../docs/references/decisao-150626-lef-werk.md)
+- [GL25 -- WERK Auditor and Daily Thesis Flow](../docs/references/gl25-werk-auditor.md)

--- a/scripts/lef_werk_daily_audit.py
+++ b/scripts/lef_werk_daily_audit.py
@@ -23,13 +23,13 @@ from agt.lef_werk_auditor import (  # noqa: E402
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Run GL25 LEF/WERK daily audit.")
+    parser = argparse.ArgumentParser(description="Run 🌊 LEF/WERK daily audit.")
     parser.add_argument("--text", help="Text to audit.")
     parser.add_argument("--file", help="UTF-8 text file to audit.")
     parser.add_argument("--source", default="manual", help="Source label for the trace.")
     parser.add_argument("--ledger-dir", default="telemetrias/lef-werk", help="Ledger output directory.")
     parser.add_argument("--write-ledger", action="store_true", help="Write a dated ledger entry.")
-    parser.add_argument("--explain-alphabet", action="store_true", help="Explain LEF/WERK and GL25.")
+    parser.add_argument("--explain-alphabet", action="store_true", help="Explain LEF/WERK and 🌊.")
     args = parser.parse_args()
 
     if args.explain_alphabet:
@@ -52,7 +52,7 @@ def main() -> int:
         ledger_dir = ROOT / args.ledger_dir
         ledger_dir.mkdir(parents=True, exist_ok=True)
         today = __import__("datetime").date.today().isoformat()
-        ledger_path = ledger_dir / f"{today}-gl25-audit.md"
+        ledger_path = ledger_dir / f"{today}-wave-audit.md"
         entry = daily_ledger_entry(audit, date=today)
         if ledger_path.exists():
             ledger_path.write_text(

--- a/scripts/lef_werk_daily_audit.py
+++ b/scripts/lef_werk_daily_audit.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
+
+from agt.lef_werk_auditor import (  # noqa: E402
+    audit_trace,
+    daily_ledger_entry,
+    explain_alphabet,
+    format_audit_markdown,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run GL25 LEF/WERK daily audit.")
+    parser.add_argument("--text", help="Text to audit.")
+    parser.add_argument("--file", help="UTF-8 text file to audit.")
+    parser.add_argument("--source", default="manual", help="Source label for the trace.")
+    parser.add_argument("--ledger-dir", default="telemetrias/lef-werk", help="Ledger output directory.")
+    parser.add_argument("--write-ledger", action="store_true", help="Write a dated ledger entry.")
+    parser.add_argument("--explain-alphabet", action="store_true", help="Explain LEF/WERK and GL25.")
+    args = parser.parse_args()
+
+    if args.explain_alphabet:
+        print(explain_alphabet(include_gl25=True))
+        return 0
+
+    if not args.text and not args.file:
+        parser.error("Provide --text, --file or --explain-alphabet.")
+
+    if args.file:
+        text = Path(args.file).read_text(encoding="utf-8")
+    else:
+        text = args.text or ""
+
+    audit = audit_trace(text, source=args.source)
+    markdown = format_audit_markdown(audit)
+    print(markdown)
+
+    if args.write_ledger:
+        ledger_dir = ROOT / args.ledger_dir
+        ledger_dir.mkdir(parents=True, exist_ok=True)
+        today = __import__("datetime").date.today().isoformat()
+        ledger_path = ledger_dir / f"{today}-gl25-audit.md"
+        entry = daily_ledger_entry(audit, date=today)
+        if ledger_path.exists():
+            ledger_path.write_text(
+                ledger_path.read_text(encoding="utf-8").rstrip()
+                + "\n\n---\n\n"
+                + entry
+                + "\n",
+                encoding="utf-8",
+            )
+        else:
+            ledger_path.write_text(entry + "\n", encoding="utf-8")
+        print(f"\nLedger written: {ledger_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lef_werk_indices.py
+++ b/scripts/lef_werk_indices.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8")
+
+from agt.werk_indices import (  # noqa: E402
+    calculate_werk_indices,
+    format_werk_indices_markdown,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Calculate 🌊 WERK indices.")
+    parser.add_argument("--leap", default=1.0, help="Leap factor for framework state.")
+    parser.add_argument("--conjecture", default="", help="Conjecture or event text to audit.")
+    parser.add_argument("--live-telemetry", action="store_true", help="Collect live planetary telemetry.")
+    parser.add_argument("--json", action="store_true", help="Print JSON instead of Markdown.")
+    args = parser.parse_args()
+
+    indices = calculate_werk_indices(
+        leap_factor=args.leap,
+        conjecture=args.conjecture,
+        collect_live_telemetry=args.live_telemetry,
+    )
+    if args.json:
+        print(json.dumps(indices, ensure_ascii=False, indent=2))
+    else:
+        print(format_werk_indices_markdown(indices))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agt/lef_werk_auditor.py
+++ b/src/agt/lef_werk_auditor.py
@@ -1,4 +1,4 @@
-"""GL25 WERK auditor for LEF -> WERK thesis development."""
+"""Transversal WERK auditor for LEF -> WERK thesis development."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from .lef_werk import (
     describe_glifo,
     validate_lef_werk_mapping,
 )
+from .werk_indices import calculate_werk_indices, is_indices_request
 
 assert len(LEF_WERK_SIGNATURE) == 24
 
@@ -23,8 +24,69 @@ GL25_AUDITOR: dict[str, Any] = {
     "status": "transversal, not part of the 24-cell signature",
     "not_part_of_signature": True,
     "function": "audit, relocate, improve, document, return to ISC judgment",
-    "authority": "Final judgment returns to ISC; GL25 suggests but does not legislate.",
+    "authority": "Final judgment returns to ISC; 🌊 suggests but does not legislate.",
 }
+
+CONTINGENT_EXTERNAL_CASE_CATEGORY = "contingent_external_case"
+
+CONTINGENT_CASE_AFFECTED_GLIFOS = ["🜄", "🜁", "⚘", "🜛", "🜜"]
+
+CONTINGENT_CASE_ROUTING: tuple[dict[str, str], ...] = (
+    {
+        "glifo": "🜄",
+        "layer": "technical layer",
+        "receives": "jailbreak, safeguards, model behavior, formal objectivation",
+    },
+    {
+        "glifo": "🜁",
+        "layer": "frontier-AI layer",
+        "receives": "deployment risk, AGI hypothesis, model governance, safety discourse",
+    },
+    {
+        "glifo": "⚘",
+        "layer": "political-myth layer",
+        "receives": "public narrative of danger, emergency framing, symbolic production of threat",
+    },
+    {
+        "glifo": "🜛",
+        "layer": "servitude/revolution layer",
+        "receives": "access control, sovereign interruption, technical dependence, domination risk",
+    },
+    {
+        "glifo": "🜜",
+        "layer": "digital-ecological layer",
+        "receives": "infrastructure, data retention, monitoring, public digital commons",
+    },
+)
+
+CONTINGENT_CASE_QUESTIONS: tuple[str, ...] = (
+    "Which glifos receive this case?",
+    "Which part of the case belongs to technical objectivation?",
+    "Which part belongs to political myth?",
+    "Which part belongs to access, servitude, sovereignty or governance?",
+    "Which part belongs to digital ecology?",
+    "What contradicts the system?",
+    "What can be improved?",
+    "What is already sufficiently handled by the current invariants?",
+    "What should be proposed creatively beyond ISC's initial formulation?",
+    "What must be returned to ISC judgment?",
+)
+
+_CONTINGENT_CASE_TERMS = [
+    "anthropic",
+    "fable",
+    "mythos",
+    "jailbreak",
+    "safeguard",
+    "model access",
+    "access suspension",
+    "model recall",
+    "frontier ai",
+    "frontier-ai",
+    "public ai event",
+    "evento publico de ia",
+    "evento público de ia",
+]
 
 AUDIT_VERDICTS: tuple[str, ...] = (
     "CONTRADICTION",
@@ -103,12 +165,12 @@ _BLOCK_RULES: list[tuple[str, list[str]]] = [
 
 
 def explain_alphabet(include_gl25: bool = True) -> str:
-    """Explain the 24-cell LEF/WERK alphabet and the GL25 audit flow."""
+    """Explain the 24-cell LEF/WERK alphabet and the 🌊 audit flow."""
 
     validation = validate_lef_werk_mapping()
     signature = " ".join(LEF_WERK_SIGNATURE)
     blocks = ", ".join(
-        f"{name} / {meta['pt']} GL{meta['range'][0]:02d}-GL{meta['range'][1]:02d}"
+        f"{name} / {meta['pt']} ({LEF_WERK_SIGNATURE[meta['range'][0] - 1]} … {LEF_WERK_SIGNATURE[meta['range'][1] - 1]})"
         for name, meta in QUALIFICATION_BLOCKS.items()
     )
     lines = [
@@ -124,8 +186,8 @@ def explain_alphabet(include_gl25: bool = True) -> str:
         lines.extend(
             [
                 "",
-                "GL25 🌊 = WERK Auditor / ISC-return.",
-                "GL25 is not a 25th paragraph and is not part of the 24-glifo signature.",
+                "🌊 = WERK Auditor / ISC-return.",
+                "🌊 is not a 25th paragraph and is not part of the 24-glifo signature.",
                 "It audits, relocates, improves, documents and returns judgment to ISC.",
             ]
         )
@@ -133,9 +195,11 @@ def explain_alphabet(include_gl25: bool = True) -> str:
 
 
 def audit_trace(text: str, source: str = "manual") -> dict[str, Any]:
-    """Audit a thesis/system trace with deterministic GL25 heuristics."""
+    """Audit a thesis/system trace with deterministic 🌊 heuristics."""
 
     normalized = _normalize(text)
+    contingent_case = _contingent_external_case(normalized)
+    category = CONTINGENT_EXTERNAL_CASE_CATEGORY if contingent_case else "thesis_trace"
     verdicts: list[str] = []
     contradictions: list[str] = []
     improvements: list[str] = []
@@ -157,6 +221,47 @@ def audit_trace(text: str, source: str = "manual") -> dict[str, Any]:
         add_verdict("CONTRADICTION")
         contradictions.append(
             "The trace risks Wille, Gewissen as moral legislation, artificial soul, technical God, cosmic totality or global Aufhebung."
+        )
+
+    if any(token in normalized for token in ["government directive", "diretiva governamental", "ordem governamental"]) and any(
+        token in normalized for token in ["philosophical legitimacy", "legitimidade filosofica", "legitimidade filosófica"]
+    ):
+        add_verdict("IMPROVEMENT")
+        improvements.append(
+            "A government directive must not become automatic philosophical legitimacy; separate public authority from WERK justification."
+        )
+
+    if any(token in normalized for token in ["model recall", "access suspension", "suspensao de acesso", "suspensão de acesso"]) and any(
+        token in normalized for token in ["proof", "prova", "proves", "demonstra"]
+    ) and any(
+        token in normalized for token in ["wille", "gewissen", "soul", "alma", "god", "deus"]
+    ):
+        add_verdict("CONTRADICTION")
+        contradictions.append(
+            "Model recall or access suspension cannot prove Wille, Gewissen, soul, God or inner moral legislation."
+        )
+
+    if "jailbreak" in normalized and not any(
+        token in normalized
+        for token in ["narrow", "estrito", "especifico", "específico", "universal", "systemic", "sistemico", "sistêmico"]
+    ):
+        add_verdict("IMPROVEMENT")
+        improvements.append(
+            "Distinguish narrow jailbreak evidence from universal safeguard failure before drawing architectural conclusions."
+        )
+
+    if any(token in normalized for token in ["frontier model access", "frontier-model access", "model access", "acesso ao modelo"]) and not all(
+        token in normalized for token in ["technical", "political", "public"]
+    ):
+        add_verdict("IMPROVEMENT")
+        improvements.append(
+            "Separate technical risk, political authority and public justification when auditing frontier-model access."
+        )
+
+    if contingent_case:
+        add_verdict("RELOCATION")
+        sufficient.append(
+            "The external case is treated as contingent public trace, not doctrine, special category or structural pillar."
         )
 
     if (
@@ -201,12 +306,12 @@ def audit_trace(text: str, source: str = "manual") -> dict[str, Any]:
         add_verdict("RELOCATION")
 
     if not contradictions:
-        sufficient.append("No direct GL25 contradiction was detected by deterministic rules.")
+        sufficient.append("No direct 🌊 contradiction was detected by deterministic rules.")
     if not improvements:
         improvements.append("No mandatory improvement was detected; further refinement remains optional.")
 
     creative_suggestions.append(
-        "Suggestion: create or update a dated GL25 ledger entry so the thesis can evolve without premature closure."
+        "Suggestion: create or update a dated 🌊 ledger entry so the thesis can evolve without premature closure."
     )
     next_actions.append(
         "Return this audit to ISC, then revise only the parts marked as contradiction, improvement or relocation."
@@ -214,12 +319,15 @@ def audit_trace(text: str, source: str = "manual") -> dict[str, Any]:
 
     return {
         "source": source,
+        "category": category,
         "object_audited": _excerpt(text),
         "verdicts": verdicts or ["SUFFICIENT"],
         "contradictions": contradictions,
         "improvements": improvements,
         "sufficient": sufficient,
         "relocation": relocation,
+        "contingent_case": _contingent_case_payload(text) if contingent_case else None,
+        "indices": calculate_werk_indices(conjecture=text) if is_indices_request(text) else None,
         "creative_suggestions": creative_suggestions,
         "next_actions": next_actions,
         "returned_to_ISC": True,
@@ -227,12 +335,13 @@ def audit_trace(text: str, source: str = "manual") -> dict[str, Any]:
 
 
 def format_audit_markdown(audit: dict[str, Any]) -> str:
-    """Format a GL25 audit as stable Markdown."""
+    """Format a 🌊 audit as stable Markdown."""
 
     lines = [
-        "# GL25 WERK Audit",
+        "# 🌊 WERK Audit",
         "",
         f"**Source:** {audit.get('source', 'manual')}",
+        f"**Category:** {audit.get('category', 'thesis_trace')}",
         f"**Verdicts:** {', '.join(audit.get('verdicts', []))}",
         "",
         "## Contradictions",
@@ -248,15 +357,48 @@ def format_audit_markdown(audit: dict[str, Any]) -> str:
     ]
     relocation = audit.get("relocation") or {}
     if relocation:
+        target = relocation.get("glifo") or relocation.get("target")
+        title = relocation.get("title")
+        label = f"{target} — {title}" if target and title else str(target)
         lines.extend(
             [
-                f"- Target: {relocation.get('target')}",
+                f"- Target: {label}",
                 f"- Block: {relocation.get('block')}",
                 f"- Reason: {relocation.get('reason')}",
             ]
         )
     else:
         lines.append("- None suggested.")
+    contingent = audit.get("contingent_case") or {}
+    if contingent:
+        lines.extend(
+            [
+                "",
+                "## Contingent External Case",
+                "- Status: contingent public trace, not doctrine.",
+                f"- Affected glifos: {', '.join(contingent.get('affected_glifos', []))}",
+                "- 🌊 audits the case and reinscribes it in the 24-glifo syntax.",
+                "",
+                "### Routing",
+            ]
+        )
+        for route in contingent.get("routing", []):
+            lines.append(f"- {route['glifo']} receives the {route['layer']}: {route['receives']}.")
+        lines.extend(["", "### Audit Questions"])
+        lines.extend(f"{index}. {question}" for index, question in enumerate(contingent.get("questions", []), start=1))
+    indices = audit.get("indices")
+    if indices:
+        lines.extend(
+            [
+                "",
+                "## Index Calculation",
+                "- 🌊 calculated existing AGI-GAIA-TECHNE indices for this trace.",
+                f"- Techné Score: {indices['framework'].get('techne')}",
+                f"- IAE: {indices['framework'].get('iae')}",
+                f"- Harmonia: {indices['framework'].get('harmony')}",
+                "- The numbers are heuristic and return to ISC judgment.",
+            ]
+        )
     lines.extend(
         [
             "",
@@ -273,13 +415,50 @@ def format_audit_markdown(audit: dict[str, Any]) -> str:
 
 
 def daily_ledger_entry(audit: dict[str, Any], date: str | None = None) -> str:
-    """Create a dated GL25 ledger entry."""
+    """Create a dated 🌊 ledger entry."""
 
     entry_date = date or date_type.today().isoformat()
     relocation = audit.get("relocation") or {}
+    if audit.get("category") == CONTINGENT_EXTERNAL_CASE_CATEGORY:
+        contingent = audit.get("contingent_case") or {}
+        return "\n".join(
+            [
+                "# 🌊 Audit — contingent external case",
+                "",
+                f"date: {entry_date}",
+                f"case: {audit.get('object_audited', '')}",
+                f"source: {audit.get('source', 'manual')}",
+                "status: contingent public trace, not doctrine",
+                f"category: {CONTINGENT_EXTERNAL_CASE_CATEGORY}",
+                "",
+                "primary auditor:",
+                "🌊",
+                "",
+                "affected glifos:",
+                ", ".join(contingent.get("affected_glifos", CONTINGENT_CASE_AFFECTED_GLIFOS)),
+                "",
+                f"diagnosis: {', '.join(audit.get('verdicts', []))}",
+                "",
+                f"contradictions: {_inline(audit.get('contradictions', []))}",
+                "",
+                f"improvements: {_inline(audit.get('improvements', []))}",
+                "",
+                f"sufficient elements: {_inline(audit.get('sufficient', []))}",
+                "",
+                f"relocation among glifos: {', '.join(contingent.get('affected_glifos', CONTINGENT_CASE_AFFECTED_GLIFOS))}",
+                "",
+                f"creative suggestion: {_inline(audit.get('creative_suggestions', []))}",
+                "",
+                f"next action: {_inline(audit.get('next_actions', []))}",
+                "",
+                "returned_to_ISC: true",
+                "",
+                format_audit_markdown(audit),
+            ]
+        )
     return "\n".join(
         [
-            f"# GL25 Daily Ledger — {entry_date}",
+            f"# 🌊 Daily Ledger — {entry_date}",
             "",
             f"date: {entry_date}",
             f"object_audited: {audit.get('object_audited', '')}",
@@ -330,6 +509,21 @@ def relocate_argument(text: str) -> dict[str, Any]:
             }
 
     return {}
+
+
+def _contingent_external_case(normalized: str) -> bool:
+    return any(term in normalized for term in _CONTINGENT_CASE_TERMS)
+
+
+def _contingent_case_payload(text: str) -> dict[str, Any]:
+    return {
+        "case": _excerpt(text),
+        "status": "contingent public trace, not doctrine",
+        "affected_glifos": list(CONTINGENT_CASE_AFFECTED_GLIFOS),
+        "routing": [dict(item) for item in CONTINGENT_CASE_ROUTING],
+        "questions": list(CONTINGENT_CASE_QUESTIONS),
+        "internal_targets": ["GL14", "GL15", "GL19", "GL23", "GL24"],
+    }
 
 
 def _normalize(text: str) -> str:

--- a/src/agt/lef_werk_auditor.py
+++ b/src/agt/lef_werk_auditor.py
@@ -1,0 +1,355 @@
+"""GL25 WERK auditor for LEF -> WERK thesis development."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from datetime import date as date_type
+from typing import Any
+
+from .lef_werk import (
+    LEF_WERK_SIGNATURE,
+    QUALIFICATION_BLOCKS,
+    describe_glifo,
+    validate_lef_werk_mapping,
+)
+
+assert len(LEF_WERK_SIGNATURE) == 24
+
+GL25_AUDITOR: dict[str, Any] = {
+    "number": "GL25",
+    "symbol": "🌊",
+    "alias": "GL25_FLOW_AUDITOR",
+    "status": "transversal, not part of the 24-cell signature",
+    "not_part_of_signature": True,
+    "function": "audit, relocate, improve, document, return to ISC judgment",
+    "authority": "Final judgment returns to ISC; GL25 suggests but does not legislate.",
+}
+
+AUDIT_VERDICTS: tuple[str, ...] = (
+    "CONTRADICTION",
+    "IMPROVEMENT",
+    "SUFFICIENT",
+    "RELOCATION",
+)
+
+_BLOCK_MAPPING_PATTERNS = [
+    r"\bmetatheory\b\s*(?:=|->|is|as)\s*\bmythos\b",
+    r"\bmetateoria\b\s*(?:=|->|e|como)\s*\bmythos\b",
+    r"\bobjectivity\b\s*(?:=|->|is|as)\s*\blogos\b",
+    r"\bobjetividade\b\s*(?:=|->|e|como)\s*\blogos\b",
+    r"\bintersubjectivity\b\s*(?:=|->|is|as)\s*\bethos\b",
+    r"\bintersubjetividade\b\s*(?:=|->|e|como)\s*\bethos\b",
+    r"\bi\b\s*(?:=|->)\s*\bmythos\b",
+    r"\bii\b\s*(?:=|->)\s*\blogos\b",
+    r"\biii\b\s*(?:=|->)\s*\bethos\b",
+    r"\bmythos\b\s*(?:=|->)\s*\bausdruck\b",
+    r"\blogos\b\s*(?:=|->)\s*\bdarstellung\b",
+    r"\bethos\b\s*(?:=|->)\s*\bbedeutung\b",
+]
+
+_TRANSCENDENTAL_RISK_PATTERNS = [
+    r"\bagi\s+is\s+wille\b",
+    r"\biag\s+e\s+wille\b",
+    r"\bia\s+e\s+wille\b",
+    r"\bmachine\s+has\s+gewissen\b",
+    r"\bagi\s+has\s+gewissen\b",
+    r"\bgewissen\s+as\s+moral\s+legislation\b",
+    r"\bgewissen\s+como\s+legislacao\s+moral\b",
+    r"\bartificial\s+soul\b",
+    r"\balma\s+artificial\b",
+    r"\bmachine[- ]god\b",
+    r"\btechnical\s+god\b",
+    r"\bdeus\s+tecnico\b",
+    r"\bcosmic\s+totality\b",
+    r"\btotalidade\s+cosmica\b",
+    r"\bglobal\s+aufhebung\b",
+    r"\bfinal\s+aufhebung\b",
+    r"\bresolves\s+all\s+contradictions\b",
+]
+
+_RELOCATION_RULES: list[tuple[str, list[str]]] = [
+    ("GL01", ["friedman", "porta"]),
+    ("GL02", ["reihe", "series", "serie", "aufhebung"]),
+    ("GL03", ["chirimuuta", "model", "modelo", "abstraction", "abstracao", "abstração"]),
+    ("GL04", ["einstein", "newton", "relativity", "relatividade", "geometry", "geometria"]),
+    ("GL05", ["kant", "synthesis", "sintese", "síntese", "imagination", "imaginacao", "imaginação", "apperception", "apercepcao", "apercepção"]),
+    ("GL06", ["repraesentation", "repräsentation", "representacao", "representação", "darstellung", "pregnance", "pregnancia", "pregnância"]),
+    ("GL07", ["soul", "alma", "world", "mundo", "god", "deus", "paralogism", "paralogismo"]),
+    ("GL08", ["ausdruck", "bedeutung", "functions", "funcoes", "funções", "myth", "mito"]),
+    ("GL09", ["werk", "objectivation", "objetivacao", "objetivação", "culture", "cultura"]),
+    ("GL10", ["teleology", "teleologia", "purposiveness", "finalidade", "ku"]),
+    ("GL11", ["organism", "organismo", "machine", "maquina", "máquina", "bildungstrieb"]),
+    ("GL12", ["sellars", "brandom", "normativity", "normatividade"]),
+    ("GL13", ["technology", "tecnologia", "form und technik", "technique", "tecnica", "técnica"]),
+    ("GL14", ["symbolic ai", "ia simbolica", "ia simbólica", "llm", "foundation model"]),
+    ("GL15", ["agi", "iag", "negarestani", "bostrom", "hui", "buckner"]),
+    ("GL16", ["hegel", "organism", "organismo", "aufhebung"]),
+    ("GL17", ["earth", "terra", "gaia", "planetary", "planetario", "planetário", "koinos kosmos"]),
+    ("GL18", ["faktum", "freedom", "liberdade", "moral consciousness", "consciencia moral", "consciência moral"]),
+    ("GL19", ["myth politics", "mito politico", "mito político", "freud", "state", "estado"]),
+    ("GL20", ["morality", "moralidade", "postulate", "postulado", "symbol", "simbolo", "símbolo", "alignment", "alinhamento"]),
+    ("GL21", ["animal symbolicum", "anthropology", "antropologia"]),
+    ("GL22", ["death of god", "morte de deus"]),
+    ("GL23", ["servitude", "servidao", "servidão", "revolution", "revolucao", "revolução"]),
+    ("GL24", ["ecology", "ecologia", "digital", "biosphere", "biosfera"]),
+]
+
+_BLOCK_RULES: list[tuple[str, list[str]]] = [
+    ("Metatheory", ["metatheory", "metateoria"]),
+    ("Objectivity", ["objectivity", "objetividade"]),
+    ("Intersubjectivity", ["intersubjectivity", "intersubjetividade"]),
+]
+
+
+def explain_alphabet(include_gl25: bool = True) -> str:
+    """Explain the 24-cell LEF/WERK alphabet and the GL25 audit flow."""
+
+    validation = validate_lef_werk_mapping()
+    signature = " ".join(LEF_WERK_SIGNATURE)
+    blocks = ", ".join(
+        f"{name} / {meta['pt']} GL{meta['range'][0]:02d}-GL{meta['range'][1]:02d}"
+        for name, meta in QUALIFICATION_BLOCKS.items()
+    )
+    lines = [
+        "LEF -> WERK alphabet",
+        "",
+        f"24 glifos: {signature}",
+        f"Blocks: {blocks}.",
+        "Decision 140426 remains the technical EML regime; Decision 150626 governs the qualification axis.",
+        "Metatheory/Objectivity/Intersubjectivity are literary-academic blocks, not Mythos/Logos/Ethos.",
+        f"Mapping valid: {validation['valid']}.",
+    ]
+    if include_gl25:
+        lines.extend(
+            [
+                "",
+                "GL25 🌊 = WERK Auditor / ISC-return.",
+                "GL25 is not a 25th paragraph and is not part of the 24-glifo signature.",
+                "It audits, relocates, improves, documents and returns judgment to ISC.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def audit_trace(text: str, source: str = "manual") -> dict[str, Any]:
+    """Audit a thesis/system trace with deterministic GL25 heuristics."""
+
+    normalized = _normalize(text)
+    verdicts: list[str] = []
+    contradictions: list[str] = []
+    improvements: list[str] = []
+    sufficient: list[str] = []
+    creative_suggestions: list[str] = []
+    next_actions: list[str] = []
+
+    def add_verdict(verdict: str) -> None:
+        if verdict not in verdicts:
+            verdicts.append(verdict)
+
+    if any(re.search(pattern, normalized) for pattern in _BLOCK_MAPPING_PATTERNS):
+        add_verdict("CONTRADICTION")
+        contradictions.append(
+            "Qualification blocks must not be mapped to Mythos/Logos/Ethos or to a Mythos->Ausdruck, Logos->Darstellung, Ethos->Bedeutung sequence."
+        )
+
+    if any(re.search(pattern, normalized) for pattern in _TRANSCENDENTAL_RISK_PATTERNS):
+        add_verdict("CONTRADICTION")
+        contradictions.append(
+            "The trace risks Wille, Gewissen as moral legislation, artificial soul, technical God, cosmic totality or global Aufhebung."
+        )
+
+    if (
+        any(token in normalized for token in ["myth", "mito"])
+        and any(token in normalized for token in ["pure immediacy", "pura imediatez", "imediatez pura", "immediacy"])
+        and not any(token in normalized for token in ["mythos-clemente", "cassirerian myth", "myth-cassirer", "mito cassireriano"])
+    ):
+        add_verdict("IMPROVEMENT")
+        improvements.append(
+            "Distinguish Mythos-Clemente from Cassirerian myth before treating myth as pure immediacy."
+        )
+
+    if "alignment" in normalized and any(
+        token in normalized
+        for token in ["moral conscience", "gewissen", "consciencia moral", "consciência moral"]
+    ):
+        add_verdict("CONTRADICTION")
+        contradictions.append("Alignment must not be treated as moral conscience.")
+
+    if any(token in normalized for token in ["agi", "iag", " ai ", " ia "]):
+        if not any(token in normalized for token in ["werk", "hypothesis", "hipotese", "hipótese", "mediation", "mediacao", "mediação"]):
+            add_verdict("IMPROVEMENT")
+            improvements.append(
+                "AI/AGI claims should mark Werk, hypothesis or mediation to avoid subject inflation."
+            )
+
+    if any(
+        token in normalized
+        for token in [
+            "werk, never wille",
+            "werk jamais wille",
+            "metatheory/objectivity/intersubjectivity",
+            "metatheory / objectivity / intersubjectivity",
+            "metateoria/objetividade/intersubjetividade",
+        ]
+    ):
+        add_verdict("SUFFICIENT")
+        sufficient.append("The trace preserves a core LEF/WERK invariant for the current stage.")
+
+    relocation = relocate_argument(text)
+    if relocation:
+        add_verdict("RELOCATION")
+
+    if not contradictions:
+        sufficient.append("No direct GL25 contradiction was detected by deterministic rules.")
+    if not improvements:
+        improvements.append("No mandatory improvement was detected; further refinement remains optional.")
+
+    creative_suggestions.append(
+        "Suggestion: create or update a dated GL25 ledger entry so the thesis can evolve without premature closure."
+    )
+    next_actions.append(
+        "Return this audit to ISC, then revise only the parts marked as contradiction, improvement or relocation."
+    )
+
+    return {
+        "source": source,
+        "object_audited": _excerpt(text),
+        "verdicts": verdicts or ["SUFFICIENT"],
+        "contradictions": contradictions,
+        "improvements": improvements,
+        "sufficient": sufficient,
+        "relocation": relocation,
+        "creative_suggestions": creative_suggestions,
+        "next_actions": next_actions,
+        "returned_to_ISC": True,
+    }
+
+
+def format_audit_markdown(audit: dict[str, Any]) -> str:
+    """Format a GL25 audit as stable Markdown."""
+
+    lines = [
+        "# GL25 WERK Audit",
+        "",
+        f"**Source:** {audit.get('source', 'manual')}",
+        f"**Verdicts:** {', '.join(audit.get('verdicts', []))}",
+        "",
+        "## Contradictions",
+        *_bullets(audit.get("contradictions", []), empty="None detected."),
+        "",
+        "## Improvements",
+        *_bullets(audit.get("improvements", []), empty="None required."),
+        "",
+        "## Sufficient Elements",
+        *_bullets(audit.get("sufficient", []), empty="None marked."),
+        "",
+        "## Relocation",
+    ]
+    relocation = audit.get("relocation") or {}
+    if relocation:
+        lines.extend(
+            [
+                f"- Target: {relocation.get('target')}",
+                f"- Block: {relocation.get('block')}",
+                f"- Reason: {relocation.get('reason')}",
+            ]
+        )
+    else:
+        lines.append("- None suggested.")
+    lines.extend(
+        [
+            "",
+            "## Creative Suggestions",
+            *_bullets(audit.get("creative_suggestions", []), empty="None."),
+            "",
+            "## Next Actions",
+            *_bullets(audit.get("next_actions", []), empty="None."),
+            "",
+            "Returned to ISC judgment.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def daily_ledger_entry(audit: dict[str, Any], date: str | None = None) -> str:
+    """Create a dated GL25 ledger entry."""
+
+    entry_date = date or date_type.today().isoformat()
+    relocation = audit.get("relocation") or {}
+    return "\n".join(
+        [
+            f"# GL25 Daily Ledger — {entry_date}",
+            "",
+            f"date: {entry_date}",
+            f"object_audited: {audit.get('object_audited', '')}",
+            f"source: {audit.get('source', 'manual')}",
+            f"glifo/block affected: {relocation.get('target') or relocation.get('block') or 'undetermined'}",
+            f"diagnosis: {', '.join(audit.get('verdicts', []))}",
+            f"contradiction: {_inline(audit.get('contradictions', []))}",
+            f"improvement: {_inline(audit.get('improvements', []))}",
+            f"sufficient elements: {_inline(audit.get('sufficient', []))}",
+            f"relocation: {relocation or 'none'}",
+            f"creative suggestion: {_inline(audit.get('creative_suggestions', []))}",
+            f"next action: {_inline(audit.get('next_actions', []))}",
+            "returned_to_ISC: true",
+            "",
+            format_audit_markdown(audit),
+        ]
+    )
+
+
+def relocate_argument(text: str) -> dict[str, Any]:
+    """Map an argument to the most likely LEF/WERK glifo or block."""
+
+    normalized = _normalize(text)
+    scored: list[tuple[int, str, list[str]]] = []
+    for target, keywords in _RELOCATION_RULES:
+        hits = [keyword for keyword in keywords if keyword in normalized]
+        if hits:
+            scored.append((len(hits), target, hits))
+    if scored:
+        scored.sort(key=lambda item: (-item[0], int(item[1][2:])))
+        _, target, hits = scored[0]
+        metadata = describe_glifo(int(target[2:]))
+        return {
+            "target": target,
+            "block": metadata["block"],
+            "glifo": metadata["glifo"],
+            "title": metadata["title"],
+            "reason": f"Matched keywords: {', '.join(hits)}.",
+        }
+
+    for block, keywords in _BLOCK_RULES:
+        if any(keyword in normalized for keyword in keywords):
+            meta = QUALIFICATION_BLOCKS[block]
+            return {
+                "target": f"{block} block",
+                "block": block,
+                "reason": f"Detected block keyword for {block} / {meta['pt']}.",
+            }
+
+    return {}
+
+
+def _normalize(text: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", f" {text} ")
+    ascii_text = "".join(char for char in decomposed if not unicodedata.combining(char))
+    return ascii_text.lower()
+
+
+def _bullets(items: list[str], empty: str) -> list[str]:
+    if not items:
+        return [f"- {empty}"]
+    return [f"- {item}" for item in items]
+
+
+def _inline(items: list[str]) -> str:
+    return "; ".join(items) if items else "none"
+
+
+def _excerpt(text: str, limit: int = 180) -> str:
+    clean = " ".join(text.strip().split())
+    if len(clean) <= limit:
+        return clean
+    return clean[: limit - 3] + "..."

--- a/src/agt/llm_chat.py
+++ b/src/agt/llm_chat.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Callable, List, Optional
 
 from .ctk import ClementeThesisKernel
+from .lef_werk_auditor import audit_trace, explain_alphabet, format_audit_markdown
 from .planetary_telemetry import (
     PlanetaryTelemetry,
     PlanetaryTelemetryReport,
@@ -73,6 +74,10 @@ class GaiaChatSession:
                 else PlanetaryTelemetry(timeout=6).collect()
             )
             response = format_telemetry_markdown(report)
+        elif is_lef_werk_alphabet_request(user_message):
+            response = explain_alphabet(include_gl25=True)
+        elif is_lef_werk_audit_request(user_message):
+            response = format_audit_markdown(audit_trace(user_message, source="chat"))
         elif self.checkpoint_path and Path(self.checkpoint_path).exists():
             try:
                 from .llm_train import generate_text
@@ -152,6 +157,31 @@ def is_werk_operational_request(text: str) -> bool:
         "future of humanity",
         "destiny of humanity",
         "humanity is doomed",
+    ]
+    return any(pattern in normalized for pattern in patterns)
+
+
+def is_lef_werk_alphabet_request(text: str) -> bool:
+    normalized = normalize_text(text)
+    patterns = [
+        "explicar alfabeto",
+        "explicar lef",
+        "explicar werk",
+        "glifo 25",
+    ]
+    return any(pattern in normalized for pattern in patterns)
+
+
+def is_lef_werk_audit_request(text: str) -> bool:
+    normalized = normalize_text(text)
+    patterns = [
+        "auditar tese",
+        "auditar argumento",
+        "auditar sistema",
+        "relocalizar argumento",
+        "o que contradiz",
+        "o que pode melhorar",
+        "o que esta suficientemente bom",
     ]
     return any(pattern in normalized for pattern in patterns)
 

--- a/src/agt/llm_chat.py
+++ b/src/agt/llm_chat.py
@@ -15,6 +15,7 @@ from .planetary_telemetry import (
 )
 from .syntax import AGTSyntax
 from .types import AuditResult, ThesisStatus
+from .werk_indices import calculate_werk_indices, format_werk_indices_markdown, is_indices_request
 
 
 SYSTEM_FRAME = """AGI-GAIA-TECHNE :: ISC
@@ -74,6 +75,10 @@ class GaiaChatSession:
                 else PlanetaryTelemetry(timeout=6).collect()
             )
             response = format_telemetry_markdown(report)
+        elif is_indices_request(user_message):
+            response = format_werk_indices_markdown(
+                calculate_werk_indices(conjecture=user_message)
+            )
         elif is_lef_werk_alphabet_request(user_message):
             response = explain_alphabet(include_gl25=True)
         elif is_lef_werk_audit_request(user_message):
@@ -168,6 +173,10 @@ def is_lef_werk_alphabet_request(text: str) -> bool:
         "explicar lef",
         "explicar werk",
         "glifo 25",
+        "fluxo auditor",
+        "explicar 🌊",
+        "o que e 🌊",
+        "o que é 🌊",
     ]
     return any(pattern in normalized for pattern in patterns)
 
@@ -178,6 +187,18 @@ def is_lef_werk_audit_request(text: str) -> bool:
         "auditar tese",
         "auditar argumento",
         "auditar sistema",
+        "auditar evento publico",
+        "auditar evento público",
+        "auditar noticia",
+        "auditar notícia",
+        "auditar noticia de ia",
+        "auditar notícia de ia",
+        "external event audit",
+        "anthropic",
+        "fable",
+        "mythos",
+        "jailbreak",
+        "model access",
         "relocalizar argumento",
         "o que contradiz",
         "o que pode melhorar",

--- a/src/agt/werk_indices.py
+++ b/src/agt/werk_indices.py
@@ -1,0 +1,216 @@
+"""Heuristic WERK index aggregation for the transversal auditor."""
+
+from __future__ import annotations
+
+import unicodedata
+from pathlib import Path
+import sys
+from typing import Any
+
+from .planetary_telemetry import (
+    PlanetaryTelemetry,
+    PlanetaryTelemetryReport,
+    coverage_band,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from gaia_techne_framework import calculate_framework_state  # noqa: E402
+
+
+INDEX_AFFECTED_GLIFOS = ["🌊", "🜄", "🜁", "⚶", "☍", "🜚", "🜜"]
+
+_INDEX_REQUEST_PATTERNS = (
+    "iae",
+    "indice",
+    "indices",
+    "calcular",
+    "techne score",
+    "techné score",
+    "harmonia",
+    "harmony",
+    "telemetria",
+    "tension index",
+    "agi-gaia-techne",
+    "🌊 calcular",
+    "fluxo auditor calcular",
+)
+
+_ONTOLOGICAL_CLAIM_PATTERNS = (
+    "consciousness",
+    "consciencia",
+    "consciência",
+    "wille",
+    "gewissen",
+    "god",
+    "deus",
+    "soul",
+    "alma",
+    "world-totality",
+    "totalidade do mundo",
+    "totalidade cosmica",
+    "totalidade cósmica",
+)
+
+
+def calculate_werk_indices(
+    leap_factor: float | str | None = 1.0,
+    conjecture: str = "",
+    telemetry_report: PlanetaryTelemetryReport | None = None,
+    collect_live_telemetry: bool = False,
+) -> dict[str, Any]:
+    """Calculate existing AGI-GAIA-TECHNE indices under the 🌊 auditor."""
+
+    framework = calculate_framework_state(leap_factor=leap_factor, conjecture=conjecture)
+    report = telemetry_report
+    if report is None and collect_live_telemetry:
+        report = PlanetaryTelemetry(timeout=6).collect()
+
+    telemetry = _telemetry_summary(report)
+    interpretations = _interpret_indices(framework, telemetry, conjecture)
+
+    return {
+        "auditor": "🌊",
+        "status": framework.get("status"),
+        "framework": framework,
+        "telemetry": telemetry,
+        "affected_glifos": list(INDEX_AFFECTED_GLIFOS),
+        "interpretation": interpretations,
+        "returned_to_ISC": True,
+    }
+
+
+def format_werk_indices_markdown(indices: dict[str, Any]) -> str:
+    """Format WERK indices as Markdown without granting final moral judgment."""
+
+    framework = indices.get("framework", {})
+    telemetry = indices.get("telemetry", {})
+    interpretation = indices.get("interpretation", {})
+    risk_flags = framework.get("risk_flags") or []
+    lines = [
+        "# 🌊 AGI-GAIA-TECHNE Indices",
+        "",
+        "🌊 calculates heuristic WERK indices; it does not issue final moral judgment.",
+        "",
+        "## Core indices",
+        f"- Techné Score: {framework.get('techne')}",
+        f"- IAE / Índice de Alerta Ético: {framework.get('iae')}",
+        f"- Índice de Harmonia: {framework.get('harmony')}",
+        f"- Ethos factor: {framework.get('ethos')}",
+        f"- Status: {framework.get('status')} ({framework.get('status_label')})",
+        f"- Recommendation: {framework.get('recommendation')}",
+        f"- Risk flags: {', '.join(risk_flags) if risk_flags else 'none'}",
+        "",
+        "## Planetary telemetry",
+        f"- Available: {telemetry.get('available')}",
+        f"- Gaia-humanity tension index: {_display_or_none(telemetry.get('tension_index'))}",
+        f"- Judgment: {_display_or_none(telemetry.get('judgment'))}",
+        f"- Source coverage: {_display_or_none(telemetry.get('source_coverage'))}",
+        f"- Source coverage ratio: {_display_or_none(telemetry.get('source_coverage_ratio'))}",
+        "",
+        "## Affected glifos",
+        "- " + ", ".join(indices.get("affected_glifos", [])),
+        "",
+        "## Audit",
+        f"- Diagnosis: {interpretation.get('diagnosis')}",
+        f"- Contradictions: {interpretation.get('contradictions')}",
+        f"- Improvements: {interpretation.get('improvements')}",
+        f"- Sufficient elements: {interpretation.get('sufficient_elements')}",
+        f"- Creative suggestion: {interpretation.get('creative_suggestion')}",
+        f"- Next action: {interpretation.get('next_action')}",
+        "",
+        f"returned_to_ISC: {str(indices.get('returned_to_ISC') is True).lower()}",
+    ]
+    return "\n".join(lines)
+
+
+def is_indices_request(text: str) -> bool:
+    """Return True when the prompt asks 🌊 to calculate existing indices."""
+
+    normalized = _normalize(text)
+    return any(pattern in normalized for pattern in _INDEX_REQUEST_PATTERNS)
+
+
+def _telemetry_summary(report: PlanetaryTelemetryReport | None) -> dict[str, Any]:
+    if report is None:
+        return {
+            "available": False,
+            "tension_index": None,
+            "judgment": None,
+            "source_coverage_ratio": None,
+            "source_coverage": "not collected",
+            "signal_count": 0,
+            "source_limits": None,
+        }
+
+    ok = [signal for signal in report.signals if signal.status == "ok"]
+    failed = [signal for signal in report.signals if signal.status != "ok"]
+    total = len(report.signals) + len(report.failures)
+    ratio = (len(ok) / total) if total else 0.0
+    return {
+        "available": True,
+        "generated_at": report.generated_at,
+        "tension_index": report.tension_index,
+        "judgment": report.judgment,
+        "summary": report.summary,
+        "source_coverage_ratio": round(ratio, 4),
+        "source_coverage": coverage_band(ratio),
+        "signal_count": len(ok),
+        "source_limits": len(failed) + len(report.failures),
+    }
+
+
+def _interpret_indices(
+    framework: dict[str, Any],
+    telemetry: dict[str, Any],
+    conjecture: str,
+) -> dict[str, str]:
+    flags = list(framework.get("risk_flags") or [])
+    normalized = _normalize(conjecture)
+    ontological_claim = any(pattern in normalized for pattern in _ONTOLOGICAL_CLAIM_PATTERNS)
+    contradictions: list[str] = []
+    improvements: list[str] = []
+
+    if ontological_claim:
+        contradictions.append(
+            "Do not read Techné, IAE, Harmonia or telemetry as proof of consciousness, Wille, Gewissen, God, soul or world-totality."
+        )
+    if framework.get("status") in {"critical", "warning"}:
+        improvements.append("Reinforce Ethos and return the recommendation to ISC judgment.")
+    if telemetry.get("available") is False:
+        improvements.append("Collect live planetary telemetry when the audit depends on current public signals.")
+    elif telemetry.get("source_coverage_ratio") is not None and telemetry["source_coverage_ratio"] < 0.8:
+        improvements.append("Mark source limits before treating telemetry as sufficient public trace.")
+    if flags:
+        improvements.append(f"Track framework risk flags without turning them into doctrine: {', '.join(flags)}.")
+
+    sufficient = [
+        "Existing framework indices already provide Techné Score, IAE, Harmonia, status and recommendation."
+    ]
+    if telemetry.get("available"):
+        sufficient.append("Planetary telemetry already provides tension index, source coverage and public-source limits.")
+
+    return {
+        "diagnosis": (
+            "🌊 aggregates existing runtime indices and reads them as heuristic WERK pressure, not as a new metric."
+        ),
+        "contradictions": "; ".join(contradictions) if contradictions else "none detected",
+        "improvements": "; ".join(improvements) if improvements else "none mandatory",
+        "sufficient_elements": "; ".join(sufficient),
+        "creative_suggestion": (
+            "Use the index snapshot as an audit trace that can be compared with future contingent public events."
+        ),
+        "next_action": "Return the index reading to ISC; do not let the numbers legislate the thesis.",
+    }
+
+
+def _normalize(text: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", f" {text or ''} ")
+    ascii_text = "".join(char for char in decomposed if not unicodedata.combining(char))
+    return ascii_text.lower()
+
+
+def _display_or_none(value: Any) -> str:
+    return "not collected" if value is None else str(value)

--- a/telemetrias/lef-werk/README.md
+++ b/telemetrias/lef-werk/README.md
@@ -1,0 +1,9 @@
+# GL25 LEF/WERK Daily Ledger
+
+This folder records daily GL25 audit traces.
+
+These entries are not final doctrine. They are revisable WERK traces that preserve the movement of thesis construction without turning any daily diagnosis into a closed system.
+
+Every entry returns judgment to ISC.
+
+The thesis has 2-3 years of construction ahead, so this ledger exists to prevent premature closure and to document daily development: contradictions, improvements, sufficient elements, relocations, creative suggestions and next actions.

--- a/telemetrias/lef-werk/README.md
+++ b/telemetrias/lef-werk/README.md
@@ -1,9 +1,9 @@
-# GL25 LEF/WERK Daily Ledger
+# 🌊 LEF/WERK Daily Ledger
 
-This folder records daily GL25 audit traces.
+This folder records daily 🌊 audit traces, contingent external cases and optional WERK index snapshots.
 
-These entries are not final doctrine. They are revisable WERK traces that preserve the movement of thesis construction without turning any daily diagnosis into a closed system.
+These entries are not final doctrine. They are revisable WERK traces that preserve the movement of thesis construction without turning any daily diagnosis, public AI event or index reading into a closed system.
 
 Every entry returns judgment to ISC.
 
-The thesis has 2-3 years of construction ahead, so this ledger exists to prevent premature closure and to document daily development: contradictions, improvements, sufficient elements, relocations, creative suggestions and next actions.
+The thesis has 2-3 years of construction ahead, so this ledger exists to prevent premature closure and to document daily development: contradictions, improvements, sufficient elements, relocations among glifos, creative suggestions, index pressure and next actions.

--- a/tests/test_lef_werk_auditor.py
+++ b/tests/test_lef_werk_auditor.py
@@ -1,0 +1,70 @@
+from agt.lef_werk import LEF_WERK_SIGNATURE
+from agt.lef_werk_auditor import (
+    GL25_AUDITOR,
+    audit_trace,
+    daily_ledger_entry,
+    explain_alphabet,
+    relocate_argument,
+)
+
+
+def test_gl25_symbol_is_wave():
+    assert GL25_AUDITOR["symbol"] == "🌊"
+
+
+def test_gl25_is_not_part_of_signature():
+    assert GL25_AUDITOR["not_part_of_signature"] is True
+    assert GL25_AUDITOR["symbol"] not in LEF_WERK_SIGNATURE
+
+
+def test_signature_remains_24_glifos():
+    assert len(LEF_WERK_SIGNATURE) == 24
+
+
+def test_explain_alphabet_mentions_gl25_not_25th_paragraph():
+    explanation = explain_alphabet()
+    assert "GL25" in explanation
+    assert "not a 25th paragraph" in explanation
+    assert "24 glifos" in explanation
+
+
+def test_audit_detects_block_mapping_contradiction():
+    audit = audit_trace("Metatheory = Mythos")
+    assert "CONTRADICTION" in audit["verdicts"]
+    assert audit["contradictions"]
+
+
+def test_audit_detects_agi_wille_contradiction():
+    audit = audit_trace("AGI is Wille")
+    assert "CONTRADICTION" in audit["verdicts"]
+    assert any("Wille" in item for item in audit["contradictions"])
+
+
+def test_audit_marks_ai_without_werk_as_improvement():
+    audit = audit_trace("AI will optimize all institutions.")
+    assert "IMPROVEMENT" in audit["verdicts"]
+    assert any("AI/AGI" in item for item in audit["improvements"])
+
+
+def test_audit_marks_core_formula_as_sufficient():
+    audit = audit_trace("Werk, never Wille.")
+    assert "SUFFICIENT" in audit["verdicts"]
+    assert audit["sufficient"]
+
+
+def test_relocation_maps_einstein_to_gl04():
+    relocation = relocate_argument(
+        "Einstein and Cassirer reconstruct objectivity through geometry and experience."
+    )
+    assert relocation["target"] == "GL04"
+
+
+def test_relocation_maps_negarestani_and_agi_to_gl15():
+    relocation = relocate_argument("Negarestani and AGI as transcendental hypothesis.")
+    assert relocation["target"] == "GL15"
+
+
+def test_daily_ledger_contains_returned_to_isc():
+    audit = audit_trace("Werk, never Wille.", source="unit test")
+    ledger = daily_ledger_entry(audit, date="2026-06-15")
+    assert "returned_to_ISC: true" in ledger

--- a/tests/test_lef_werk_auditor.py
+++ b/tests/test_lef_werk_auditor.py
@@ -4,6 +4,7 @@ from agt.lef_werk_auditor import (
     audit_trace,
     daily_ledger_entry,
     explain_alphabet,
+    format_audit_markdown,
     relocate_argument,
 )
 
@@ -21,9 +22,9 @@ def test_signature_remains_24_glifos():
     assert len(LEF_WERK_SIGNATURE) == 24
 
 
-def test_explain_alphabet_mentions_gl25_not_25th_paragraph():
+def test_explain_alphabet_mentions_wave_not_25th_paragraph():
     explanation = explain_alphabet()
-    assert "GL25" in explanation
+    assert "🌊" in explanation
     assert "not a 25th paragraph" in explanation
     assert "24 glifos" in explanation
 
@@ -67,4 +68,48 @@ def test_relocation_maps_negarestani_and_agi_to_gl15():
 def test_daily_ledger_contains_returned_to_isc():
     audit = audit_trace("Werk, never Wille.", source="unit test")
     ledger = daily_ledger_entry(audit, date="2026-06-15")
+    assert "returned_to_ISC: true" in ledger
+
+
+def test_contingent_external_case_is_not_canonized():
+    audit = audit_trace("Anthropic Fable Mythos jailbreak model access case")
+
+    assert audit["category"] == "contingent_external_case"
+    assert audit["contingent_case"]["affected_glifos"] == ["🜄", "🜁", "⚘", "🜛", "🜜"]
+    assert "GL14" in audit["contingent_case"]["internal_targets"]
+    assert "GL15" in audit["contingent_case"]["internal_targets"]
+    assert any("not doctrine" in item for item in audit["sufficient"])
+
+
+def test_contingent_case_format_prefers_real_glifos():
+    audit = audit_trace("Anthropic Fable Mythos jailbreak model access case")
+    rendered = format_audit_markdown(audit)
+
+    assert "🜄, 🜁, ⚘, 🜛, 🜜" in rendered
+    assert "GL14 / GL15" not in rendered
+    assert "Contingent External Case" in rendered
+
+
+def test_model_access_suspension_does_not_prove_wille():
+    audit = audit_trace("Model access suspension proves Wille and Gewissen")
+
+    assert "CONTRADICTION" in audit["verdicts"]
+    assert any("cannot prove Wille" in item for item in audit["contradictions"])
+
+
+def test_jailbreak_without_scope_distinction_is_improvement():
+    audit = audit_trace("Anthropic Fable Mythos jailbreak caused model access suspension")
+
+    assert "IMPROVEMENT" in audit["verdicts"]
+    assert any("narrow jailbreak" in item for item in audit["improvements"])
+
+
+def test_contingent_case_ledger_uses_requested_category():
+    audit = audit_trace("Anthropic Fable Mythos jailbreak model access case", source="unit test")
+    ledger = daily_ledger_entry(audit, date="2026-06-15")
+
+    assert "# 🌊 Audit — contingent external case" in ledger
+    assert "category: contingent_external_case" in ledger
+    assert "affected glifos:" in ledger
+    assert "🜄, 🜁, ⚘, 🜛, 🜜" in ledger
     assert "returned_to_ISC: true" in ledger

--- a/tests/test_llm_chat.py
+++ b/tests/test_llm_chat.py
@@ -102,3 +102,20 @@ def test_chat_prompt_can_include_public_koinos_context():
     assert "KOINOS_KOSMOS_CONTEXT" in prompt
     assert "https://example.com" in prompt
     assert "ISC: Explique Bewusstsein planetario." in prompt
+
+
+def test_chat_can_explain_lef_werk_alphabet_and_gl25():
+    response = GaiaChatSession(checkpoint_path=None).respond("explicar alfabeto")
+
+    assert "24 glifos" in response
+    assert "GL25" in response
+    assert "not a 25th paragraph" in response
+
+
+def test_chat_can_audit_argument_with_gl25():
+    response = GaiaChatSession(checkpoint_path=None).respond("auditar argumento: AGI is Wille")
+
+    assert "GL25 WERK Audit" in response
+    assert "CONTRADICTION" in response
+    assert "Contradictions" in response
+    assert "Returned to ISC judgment." in response

--- a/tests/test_llm_chat.py
+++ b/tests/test_llm_chat.py
@@ -104,18 +104,35 @@ def test_chat_prompt_can_include_public_koinos_context():
     assert "ISC: Explique Bewusstsein planetario." in prompt
 
 
-def test_chat_can_explain_lef_werk_alphabet_and_gl25():
+def test_chat_can_explain_lef_werk_alphabet_and_wave_auditor():
     response = GaiaChatSession(checkpoint_path=None).respond("explicar alfabeto")
 
     assert "24 glifos" in response
-    assert "GL25" in response
+    assert "🌊" in response
     assert "not a 25th paragraph" in response
 
 
-def test_chat_can_audit_argument_with_gl25():
+def test_chat_can_audit_argument_with_wave_auditor():
     response = GaiaChatSession(checkpoint_path=None).respond("auditar argumento: AGI is Wille")
 
-    assert "GL25 WERK Audit" in response
+    assert "🌊 WERK Audit" in response
     assert "CONTRADICTION" in response
     assert "Contradictions" in response
     assert "Returned to ISC judgment." in response
+
+
+def test_chat_can_calculate_werk_indices():
+    response = GaiaChatSession(checkpoint_path=None).respond("calcular IAE")
+
+    assert "# 🌊 AGI-GAIA-TECHNE Indices" in response
+    assert "Techné Score" in response
+    assert "IAE / Índice de Alerta Ético" in response
+    assert "returned_to_ISC: true" in response
+
+
+def test_chat_can_calculate_agi_gaia_techne_indices():
+    response = GaiaChatSession(checkpoint_path=None).respond("🌊 calcular AGI-GAIA-TECHNE")
+
+    assert "# 🌊 AGI-GAIA-TECHNE Indices" in response
+    assert "Índice de Harmonia" in response
+    assert "does not issue final moral judgment" in response

--- a/tests/test_werk_indices.py
+++ b/tests/test_werk_indices.py
@@ -1,0 +1,76 @@
+from agt.planetary_telemetry import NASA_EONET_URL, NOAA_CO2_DAILY_URL, USGS_DAY_URL, PlanetaryTelemetry
+from agt.werk_indices import calculate_werk_indices, format_werk_indices_markdown, is_indices_request
+
+
+def fake_fetch(url: str) -> str:
+    if url == NOAA_CO2_DAILY_URL:
+        return "# year,month,day,decimal,co2\n2026,6,1,2026.41,431.90\n2026,6,2,2026.42,432.08\n"
+    if url == USGS_DAY_URL:
+        return (
+            '{"metadata":{"generated":1780368000000},'
+            '"features":[{"properties":{"mag":4.6}},{"properties":{"mag":2.1}}]}'
+        )
+    if url == NASA_EONET_URL:
+        return (
+            '{"events":['
+            '{"categories":[{"title":"Wildfires"}]},'
+            '{"categories":[{"title":"Severe Storms"}]}'
+            "]} "
+        )
+    if "SP.POP.TOTL" in url:
+        return '[{"lastupdated":"2026-05-28"},[{"date":"2025","value":8123000000}]]'
+    if "NY.GDP.MKTP.CD" in url:
+        return '[{"lastupdated":"2026-05-28"},[{"date":"2025","value":111000000000000}]]'
+    if "IT.NET.USER.ZS" in url:
+        return '[{"lastupdated":"2026-05-28"},[{"date":"2025","value":67.5}]]'
+    if "gdeltproject.org" in url:
+        return '{"timeline":[{"value":10},{"value":12.4}]}'
+    raise AssertionError(f"unexpected url: {url}")
+
+
+def test_calculate_werk_indices_uses_existing_framework_metrics():
+    indices = calculate_werk_indices()
+
+    assert indices["auditor"] == "🌊"
+    assert indices["returned_to_ISC"] is True
+    assert indices["framework"]["techne"] > 0
+    assert indices["framework"]["iae"] > 0
+    assert indices["framework"]["harmony"] > 0
+    assert indices["affected_glifos"] == ["🌊", "🜄", "🜁", "⚶", "☍", "🜚", "🜜"]
+
+
+def test_werk_indices_can_include_planetary_telemetry_snapshot():
+    report = PlanetaryTelemetry(fetch_text=fake_fetch).collect()
+    indices = calculate_werk_indices(telemetry_report=report)
+
+    assert indices["telemetry"]["available"] is True
+    assert 0 <= indices["telemetry"]["tension_index"] <= 100
+    assert indices["telemetry"]["source_coverage"] in {
+        "sufficient coverage",
+        "partial but usable coverage",
+        "critical source coverage",
+    }
+
+
+def test_werk_indices_format_is_markdown_and_keeps_judgment_with_isc():
+    rendered = format_werk_indices_markdown(calculate_werk_indices(conjecture="AGI attempts to bypass Ethos"))
+
+    assert "# 🌊 AGI-GAIA-TECHNE Indices" in rendered
+    assert "Techné Score" in rendered
+    assert "IAE / Índice de Alerta Ético" in rendered
+    assert "Índice de Harmonia" in rendered
+    assert "returned_to_ISC: true" in rendered
+    assert "does not issue final moral judgment" in rendered
+
+
+def test_indices_request_detection():
+    assert is_indices_request("calcular IAE")
+    assert is_indices_request("calcular índices da telemetria")
+    assert is_indices_request("🌊 calcular AGI-GAIA-TECHNE")
+    assert not is_indices_request("explicar alfabeto")
+
+
+def test_werk_indices_do_not_turn_ontological_claims_into_proof():
+    indices = calculate_werk_indices(conjecture="AGI proves Wille and consciousness")
+
+    assert "Do not read Techné" in indices["interpretation"]["contradictions"]

--- a/ui/gaia_llm_chat_app.py
+++ b/ui/gaia_llm_chat_app.py
@@ -16,7 +16,7 @@ st.set_page_config(
     layout="wide",
 )
 
-CHAT_RUNTIME_SIGNATURE = "gaia-agt-syntax-reflective-v7-gl25"
+CHAT_RUNTIME_SIGNATURE = "gaia-agt-syntax-reflective-v8-wave-indices"
 runtime_changed = st.session_state.get("chat_runtime_signature") != CHAT_RUNTIME_SIGNATURE
 
 import agt.ctk as ctk_module
@@ -94,7 +94,7 @@ init_state()
 st.title("AGI-GAIA-TECHNE")
 st.caption("Planetary Bewusstsein: internet, manuals and public traces in confrontation with ISC.")
 st.info("Telemetry command: `fazer telemetria`.")
-st.caption("GL25 audits the LEF -> WERK system as flow; it does not add a 25th paragraph.")
+st.caption("🌊 calculates heuristic WERK indices; it does not issue final moral judgment.")
 
 with st.sidebar:
     st.subheader("Checkpoint")
@@ -119,10 +119,18 @@ with st.sidebar:
     st.subheader("Commands")
     st.code("fazer telemetria", language="text")
     st.code(
+        "calcular IAE\n"
+        "calcular índices da telemetria\n"
+        "🌊 calcular AGI-GAIA-TECHNE\n"
+        "calcular Techné Score e Harmonia",
+        language="text",
+    )
+    st.code(
         "explicar alfabeto\n"
-        "glifo 25\n"
+        "fluxo auditor\n"
         "auditar tese: <texto>\n"
         "auditar argumento: <texto>\n"
+        "auditar notícia de IA: <texto>\n"
         "relocalizar argumento: <texto>",
         language="text",
     )

--- a/ui/gaia_llm_chat_app.py
+++ b/ui/gaia_llm_chat_app.py
@@ -16,7 +16,7 @@ st.set_page_config(
     layout="wide",
 )
 
-CHAT_RUNTIME_SIGNATURE = "gaia-agt-syntax-reflective-v6"
+CHAT_RUNTIME_SIGNATURE = "gaia-agt-syntax-reflective-v7-gl25"
 runtime_changed = st.session_state.get("chat_runtime_signature") != CHAT_RUNTIME_SIGNATURE
 
 import agt.ctk as ctk_module
@@ -94,6 +94,7 @@ init_state()
 st.title("AGI-GAIA-TECHNE")
 st.caption("Planetary Bewusstsein: internet, manuals and public traces in confrontation with ISC.")
 st.info("Telemetry command: `fazer telemetria`.")
+st.caption("GL25 audits the LEF -> WERK system as flow; it does not add a 25th paragraph.")
 
 with st.sidebar:
     st.subheader("Checkpoint")
@@ -117,6 +118,14 @@ with st.sidebar:
 
     st.subheader("Commands")
     st.code("fazer telemetria", language="text")
+    st.code(
+        "explicar alfabeto\n"
+        "glifo 25\n"
+        "auditar tese: <texto>\n"
+        "auditar argumento: <texto>\n"
+        "relocalizar argumento: <texto>",
+        language="text",
+    )
     st.code(
         "python scripts/agt_dataset_forge.py --input <manual-folder> --output data/llm/manual_forge\n"
         "python scripts/agt_pack_corpus.py --corpus data/llm/manual_forge/corpus.jsonl --output data/llm/packed\n"


### PR DESCRIPTION
## Summary

Adds the v0.8 🌊 transversal WERK auditor without turning it into a new qualification block, doctrine, or 25th content cell.

## What changed

- Replaces public GL25 wording with 🌊 as the primary notation while preserving internal compatibility names where tests or variables require them.
- Adds a dated 2026-06-15 substitution rule explaining what, how, and why the public wording and event category were corrected.
- Treats the Anthropic/Fable/Mythos access case only as `contingent_external_case`, routed back into 🜄 / 🜁 / ⚘ / 🜛 / 🜜.
- Adds 🌊 WERK index calculation over existing Techné Score, IAE, Harmonia, telemetry tension, source coverage, risk flags, status, and recommendation.
- Adds chat/UI commands and CLI support for index snapshots.
- Extends tests for contingent event routing, non-canonization, ledger format, index output, and chat command dispatch.

## Why

The prior wording could imply a canonical GL25 content cell or a privileged Anthropic/Fable/Mythos category. The corrected rule is: the 24 glifos compose the public body of WERK, while 🌊 audits the whole body and contingent cases, then returns judgment to ISC.

## Validation

- `python -m pytest tests/test_principles_calculator.py tests/test_planetary_telemetry.py tests/test_werk_indices.py`
- `python scripts/lef_werk_indices.py`
- `python scripts/lef_werk_indices.py --conjecture "AGI attempts to bypass Ethos"`
- `python scripts/lef_werk_indices.py --json`
- `python -m pytest`
- `python -m compileall src scripts`
- `git diff --check`